### PR TITLE
Fix black screen in Unity games: real MSAA resolve on native ES 2.0 backend

### DIFF
--- a/src/gles/gl_bindings/build.rs
+++ b/src/gles/gl_bindings/build.rs
@@ -84,6 +84,17 @@ fn main() {
             "GL_EXT_texture_format_BGRA8888",
             "GL_OES_mapbuffer",
             "GL_OES_vertex_array_object",
+            // GL_APPLE_framebuffer_multisample provides the native
+            // glRenderbufferStorageMultisampleAPPLE /
+            // glResolveMultisampleFramebufferAPPLE entry points (and the
+            // GL_READ_FRAMEBUFFER_APPLE / GL_DRAW_FRAMEBUFFER_APPLE targets)
+            // used by the canonical iOS EAGLView MSAA pattern. Real ES 2.0
+            // drivers on iPhone OS hardware (and many Android GPUs, e.g.
+            // Adreno) export this extension, so route the guest's APPLE
+            // multisample calls straight through to the host driver instead
+            // of degrading to a no-op resolve (which leaves the drawable
+            // empty → black screen).
+            "GL_APPLE_framebuffer_multisample",
         ],
     )
     .write_bindings(GlobalGenerator, &mut file)
@@ -117,6 +128,11 @@ fn main() {
             // `glMapBufferRange`. Include them so guest code that drives an
             // ES 3.0 backend via an ES-1.1-shaped API can still map buffers.
             "GL_OES_mapbuffer",
+            // As with the ES 2.0 registry above, expose the native Apple
+            // multisample resolve entry points so the ES 3.0 native backend
+            // can honour the canonical iOS EAGLView MSAA pattern on drivers
+            // that advertise GL_APPLE_framebuffer_multisample.
+            "GL_APPLE_framebuffer_multisample",
         ],
     )
     .write_bindings(GlobalGenerator, &mut file)

--- a/src/gles/gles2_native.rs
+++ b/src/gles/gles2_native.rs
@@ -932,6 +932,56 @@ impl GLES for GLES2Native<'_> {
     ) {
         gles2::RenderbufferStorage(target, internalformat, width, height)
     }
+    // GL_APPLE_framebuffer_multisample
+    //
+    // The canonical iOS EAGLView MSAA pattern allocates a multisample
+    // "sample" renderbuffer, renders into it, then resolves it into the
+    // single-sample "resolve" renderbuffer whose color storage is the
+    // CAEAGLLayer drawable, and finally calls `-presentRenderbuffer:`.
+    // Real iPhone OS ES 2.0 drivers expose this extension natively, and so
+    // do many Android GPUs (e.g. Adreno advertises
+    // GL_APPLE_framebuffer_multisample). When the host driver exports the
+    // native entry points we forward to them directly; otherwise we degrade
+    // gracefully so the app keeps running (see the generic-backend fallback
+    // in `gles_generic`).
+    unsafe fn RenderbufferStorageMultisampleAPPLE(
+        &mut self,
+        target: GLenum,
+        samples: GLsizei,
+        internalformat: GLenum,
+        width: GLsizei,
+        height: GLsizei,
+    ) {
+        if gles2::RenderbufferStorageMultisampleAPPLE::is_loaded() {
+            gles2::RenderbufferStorageMultisampleAPPLE(
+                target,
+                samples,
+                internalformat,
+                width,
+                height,
+            )
+        } else {
+            log_once!(
+                "RenderbufferStorageMultisampleAPPLE: host ES 2.0 driver lacks \
+                 GL_APPLE_framebuffer_multisample; using single-sample storage"
+            );
+            gles2::RenderbufferStorage(target, internalformat, width, height)
+        }
+    }
+    unsafe fn ResolveMultisampleFramebufferAPPLE(&mut self) {
+        if gles2::ResolveMultisampleFramebufferAPPLE::is_loaded() {
+            // The app has already bound the sample framebuffer to
+            // GL_READ_FRAMEBUFFER_APPLE and the resolve framebuffer to
+            // GL_DRAW_FRAMEBUFFER_APPLE; the driver does the resolve.
+            gles2::ResolveMultisampleFramebufferAPPLE()
+        } else {
+            log_once!(
+                "ResolveMultisampleFramebufferAPPLE: host ES 2.0 driver lacks \
+                 GL_APPLE_framebuffer_multisample; relying on the single-sample \
+                 fallback from RenderbufferStorageMultisampleAPPLE"
+            );
+        }
+    }
     unsafe fn FramebufferRenderbuffer(
         &mut self,
         target: GLenum,


### PR DESCRIPTION
## Проблема

Игры на Unity (например **Turbo Dismount**, см. приложенный лог) показывают заставку, потом **чёрный экран**, при этом звук играет и игровой цикл живёт (в логе `presentRenderbuffer:] frame 60 reached`).

В логе видно ключевую строку:

```
touchHLE::gles::gles_generic: ResolveMultisampleFramebufferAPPLE: backend lacks a real resolve;
  relying on the single-sample fallback ...
```

Хост-устройство (Adreno 750, OpenGL ES 3.2) **рекламирует** `GL_APPLE_framebuffer_multisample` в списке расширений, но активный бэкенд `GLES2NativeContext` не использовал его.

## Причина

Unity-игры используют канонический iOS-паттерн MSAA из документации Apple ("Working with EAGL Contexts"):
1. рендер в multisample («sample») фреймбуфер;
2. `glResolveMultisampleFramebufferAPPLE()` — разрешение в single-sample («resolve») фреймбуфер, чей color-renderbuffer привязан к `CAEAGLLayer` drawable;
3. `-presentRenderbuffer:`.

Нативный ES 2.0 бэкенд (`GLES2Native`) **не переопределял** `RenderbufferStorageMultisampleAPPLE` / `ResolveMultisampleFramebufferAPPLE`, поэтому вызовы попадали в no-op заглушку в `gles_generic`. Resolve-renderbuffer оставался пустым → чёрный экран, хотя всё остальное работало.

## Исправление

- Добавлено расширение `GL_APPLE_framebuffer_multisample` в генераторы биндингов `gles2` и `gles30`, чтобы стали доступны нативные точки входа `glRenderbufferStorageMultisampleAPPLE` / `glResolveMultisampleFramebufferAPPLE` и константы `GL_READ/DRAW_FRAMEBUFFER_APPLE`.
- В `GLES2Native` реализованы обе функции: при наличии нативных точек входа (`is_loaded()`) вызов проксируется прямо в драйвер; иначе — корректная деградация до single-sample (как раньше). Это зеркалит уже существующую реальную реализацию resolve в бэкенде `gles1_on_gl2`.

Без заглушек: используется реальный аппаратный resolve драйвера, когда он доступен.

## Проверка

- `cargo build` — успешно.
- `cargo clippy` — 0 ошибок в изменённых файлах.
- Бинарь запускается (`touchHLE --help`).

Ссылки: Apple "Working with EAGL Contexts"; спецификация `GL_APPLE_framebuffer_multisample`.