### PR TITLE
fix(pthread): pthread_attr_getstacksize checked wrong magic number (always returned EINVAL)

### DIFF
--- a/src/libc/pthread/thread.rs
+++ b/src/libc/pthread/thread.rs
@@ -166,7 +166,7 @@ fn pthread_attr_getstacksize(
     if attr.is_null() {
         return EINVAL;
     }
-    check_magic!(env, attr, MAGIC_THREAD);
+    check_magic!(env, attr, MAGIC_ATTR);
     let size = env.mem.read(attr).stacksize;
     env.mem.write(stacksize, size);
     0


### PR DESCRIPTION
## What

`pthread_attr_getstacksize()` validated the incoming `pthread_attr_t`
with the **wrong magic number**: it used `MAGIC_THREAD` (the magic used
for `pthread_t` / `OpaqueThread`) instead of `MAGIC_ATTR` (the magic
actually written into a `pthread_attr_t` by `pthread_attr_init` /
`DEFAULT_ATTR`).

```rust
// before
check_magic!(env, attr, MAGIC_THREAD);
// after
check_magic!(env, attr, MAGIC_ATTR);
```

## Why it matters

`check_magic!` returns `EINVAL` on mismatch. Because a valid
`pthread_attr_t` always carries `MAGIC_ATTR`, the check could **never**
succeed, so `pthread_attr_getstacksize()` always returned `EINVAL`
without writing the out-parameter. Any guest that queries the configured
stack size of an attributes object (common in engines/runtimes that
configure worker-thread stacks before `pthread_create`) read back
uninitialized memory and got a spurious error.

Every sibling function in this file (`pthread_attr_setstacksize`,
`pthread_attr_setdetachstate`, `pthread_attr_getdetachstate`,
`pthread_attr_setstack`, …) correctly checks `MAGIC_ATTR`; this one was
the lone outlier, so this restores consistency with the rest of the
attribute API.

Reference: Apple `pthread_attr_getstacksize(3)` —
https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/pthread.3.html

## Scope / honesty

This is a single, self-contained correctness fix found while
investigating an early-startup crash log (Asphalt 8, crash right after
the first `pthread_create`). I'm **not** claiming this alone fixes
Asphalt 8 end-to-end — that game needs more investigation — but this is
a real bug with a real, minimal fix and no stubs. Build wasn't run in
this environment (toolchain/deps unavailable); the change swaps one
existing constant for another existing constant of the same type.
