### PR TITLE
Fix black screen on Adreno for Ninjago: Rise of the Snakes (com.lego.riseofthesnakes)

### DIFF
--- a/touchHLE_default_options.txt
+++ b/touchHLE_default_options.txt
@@ -251,6 +251,14 @@ com.chillingo.redball3hd: --landscape-left
 # pointer to the calling host site.
 com.lego.NinjagoSpinjitzuScavengerHunt: --landscape-left --fix-texture-min-filter --trace-gl-errors
 
+# Ninjago: Rise of the Snakes
+# Same fixed-function texture-completeness issue as the other LEGO Ninjago
+# title above. The log shows the bundle id as com.lego.riseofthesnakes, and
+# on strict Adreno ES 1.1 drivers the default mipmapped min filter makes the
+# game texture incomplete unless we force GL_TEXTURE_MIN_FILTER=GL_LINEAR
+# after the level-0 upload.
+com.lego.riseofthesnakes: --landscape-left --fix-texture-min-filter --trace-gl-errors
+
 # Resident Evil Degeneration (jp.co.capcom.residentevil.en)
 # Ported from touchHLE upstream commit 1bd22431 ("Default options for
 # Resident Evil Degeneration"). The game runs in landscape but its


### PR DESCRIPTION
## Problem

Reported symptom: **black screen on Adreno (works on Mali), render loop alive, audio plays, touches register.** From the attached `touchHLE_log.txt`:

```
Display name: Ninjago Snake
Identifier: com.lego.riseofthesnakes
...
No options found for this app in touchHLE_default_options.txt
...
First glTexImage2D(512x512, internalformat=0x1907, format=0x1907, type=0x1401)   # GL_RGB, level 0
...
Driver info: OpenGL ES-CM 1.1 / Qualcomm / Adreno (TM) 750
```

## Root cause

This is a pure ES 1.1 fixed-function LEGO title with the **exact texture-completeness bug already documented and fixed** for the sibling title `com.lego.NinjagoSpinjitzuScavengerHunt`:

- The game uploads a **level-0-only** texture (`glTexImage2D(512x512, GL_RGB)`) and never sets `GL_TEXTURE_MIN_FILTER`, so it stays at the ES 1.1 default `GL_NEAREST_MIPMAP_LINEAR`.
- A mipmap min-filter on a texture with no mipmap chain is **incomplete**. Lenient drivers (Apple PowerVR, Mesa) still sample it; **strict Qualcomm Adreno native ES 1.1 samples an incomplete texture as opaque black** → alive render loop + audio + a fully black screen. This is precisely why it works on Mali but is black on Adreno.

The reason the existing workaround never kicked in is mundane and confirmed by the log: the running game's bundle id is `com.lego.riseofthesnakes`, which had **no entry** in `touchHLE_default_options.txt` — *"No options found for this app."*

## Fix

Add a per-app default-options entry for `com.lego.riseofthesnakes`, matching the established pattern for the other LEGO Ninjago title:

```
com.lego.riseofthesnakes: --landscape-left --fix-texture-min-filter --trace-gl-errors
```

`--fix-texture-min-filter` forces `GL_TEXTURE_MIN_FILTER=GL_LINEAR` after the level-0 upload so the texture is complete on all drivers, restoring the iPhone (PowerVR) behaviour the emulator targets. The guest can still override the filter later. This is real per-app configuration using existing, reviewed machinery — no stubbing.

The `android/app/src/main/assets/touchHLE_default_options.txt` copy is a symlink to the root file, so it inherits the fix automatically.

## Apple documentation basis

Per Apple's *OpenGL ES Programming Guide* — "Best Practices for Working with Texture Data" and the Glossary — a non-power-of-two / level-0-only texture must use a non-mipmap min filter (`GL_LINEAR`/`GL_NEAREST`) together with `GL_CLAMP_TO_EDGE` wrapping to be a *complete* texture; a mipmap min-filter without a full mipmap chain yields an incomplete texture that need not render.

## Testing

Source-level change to a per-app options entry using already-shipping flags (`--landscape-left`, `--fix-texture-min-filter`, `--trace-gl-errors`), parsed in `src/options.rs` and implemented in `src/frameworks/opengles/gles_guest.rs`. No code path changes. A full Rust build/CI run on this change should be exercised by GitHub Actions on the PR.
