### PR TITLE
Fix opaque RGB-PVRTC textures decoding with stray alpha (black screen with audio)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,7 @@ Compatibility:
 
 Quality and performance:
 
+- Fixed opaque `COMPRESSED_RGB_PVRTC_*` textures rendering as a black screen (with working audio and touch input) on hosts that lack `GL_IMG_texture_compression_pvrtc` and therefore software-decode PVRTC to RGBA — for example Adreno/Mali devices and the GLES1-on-GL2 layer. Per the `IMG_texture_compression_pvrtc` spec the RGB variants have a base internal format of RGB, so their sampled alpha must be 1.0; the software decoder was instead keeping the PVRTC block's stray per-texel alpha and uploading as `GL_RGBA`, so apps that draw with `GL_BLEND` + `GL_SRC_ALPHA` blended their world away to nothing. The decoded alpha is now forced opaque (and uploaded with a matching `GL_RGB` base format) for the RGB variants, across all GLES backends.
 - Overlapping characters in text now render correctly. (@Xertes0)
 - touchHLE now avoids polling for events more often than 120Hz. Previously, it would sometimes poll many times more often than that, which could be very bad for performance. This change improves performance in basically all apps, though the effects on the supported apps from previous releases are fairly subtle. (@hikari-no-yume)
 - The macOS-only memory leak of up to 0.4MB/s seems to have been fixed! (@hikari-no-yume)

--- a/src/gles/gles1_on_gl2.rs
+++ b/src/gles/gles1_on_gl2.rs
@@ -2666,8 +2666,14 @@ impl GLES for GLES1OnGL2<'_> {
                 );
                 return;
             };
-            let pixels =
-                crate::image::decode_pvrtc(data_slice, is_pvrtc_2bit, width_u, height_u);
+            let is_opaque = matches!(
+                format,
+                gles11::COMPRESSED_RGB_PVRTC_2BPPV1_IMG
+                    | gles11::COMPRESSED_RGB_PVRTC_4BPPV1_IMG
+            );
+            let pixels = crate::image::decode_pvrtc_with_alpha(
+                data_slice, is_pvrtc_2bit, width_u, height_u, is_opaque,
+            );
             gl21::TexSubImage2D(
                 target,
                 level,

--- a/src/gles/util.rs
+++ b/src/gles/util.rs
@@ -200,6 +200,22 @@ pub fn try_decode_pvrtc(
         _ => return false,
     };
 
+    // The `COMPRESSED_RGB_PVRTC_*` formats have a base internal format of RGB
+    // per the IMG_texture_compression_pvrtc spec, so their sampled alpha must
+    // be 1.0. The `COMPRESSED_RGBA_PVRTC_*` formats carry real alpha. Decode
+    // accordingly and upload with a matching uncompressed base format so the
+    // host driver enforces the same alpha semantics PowerVR / Apple hardware
+    // would.
+    let is_opaque = matches!(
+        internalformat,
+        gles11::COMPRESSED_RGB_PVRTC_4BPPV1_IMG | gles11::COMPRESSED_RGB_PVRTC_2BPPV1_IMG
+    );
+    let upload_format = if is_opaque {
+        gles11::RGB
+    } else {
+        gles11::RGBA
+    };
+
     if border != 0 {
         log!(
             "Warning: try_decode_pvrtc: invalid non-zero border ({border}) for PVRTC \
@@ -246,12 +262,15 @@ pub fn try_decode_pvrtc(
         return true;
     }
 
-    let pixels = crate::image::decode_pvrtc(pvrtc_data, is_2bit, width_u, height_u);
+    let pixels =
+        crate::image::decode_pvrtc_with_alpha(pvrtc_data, is_2bit, width_u, height_u, is_opaque);
     unsafe {
         gles.TexImage2D(
             target,
             level,
-            gles11::RGBA as _,
+            // internalformat selects the base format (RGB drops alpha → 1.0,
+            // RGBA keeps it). The pixel data is always tightly-packed RGBA8.
+            upload_format as _,
             width,
             height,
             border,

--- a/src/image.rs
+++ b/src/image.rs
@@ -318,7 +318,32 @@ pub fn gamma_decode(intensity: f32) -> f32 {
 
 /// Decodes Imagination Technologies' PVRTC texture compression format to
 /// RGBA (8 bits per channel).
+///
+/// `is_opaque` must be `true` for the `COMPRESSED_RGB_PVRTC_*` (no-alpha)
+/// internal formats and `false` for the `COMPRESSED_RGBA_PVRTC_*` variants.
+/// Per the `IMG_texture_compression_pvrtc` extension spec, the RGB variants
+/// have a base internal format of `RGB`, so sampling them must yield an alpha
+/// of 1.0 — exactly as real PowerVR / Apple hardware does. The underlying
+/// PVRTDecompress routine always produces a per-texel alpha value (PVRTC
+/// blocks can individually opt into a "transparent" colour mode regardless of
+/// the requested internal format), so for the opaque formats we overwrite the
+/// decoded alpha with 0xFF. Without this, opaque textures uploaded as GL_RGBA
+/// keep the decoder's stray sub-255 alpha and, when the app has GL_BLEND
+/// enabled with GL_SRC_ALPHA, blend away to nothing — producing a black screen
+/// while audio and input keep working.
 pub fn decode_pvrtc(pvrtc_data: &[u8], is_2bit: bool, width: u32, height: u32) -> Vec<u32> {
+    decode_pvrtc_with_alpha(pvrtc_data, is_2bit, width, height, false)
+}
+
+/// Like [decode_pvrtc], but lets the caller declare whether the source format
+/// is one of the opaque `COMPRESSED_RGB_PVRTC_*` variants (`is_opaque = true`).
+pub fn decode_pvrtc_with_alpha(
+    pvrtc_data: &[u8],
+    is_2bit: bool,
+    width: u32,
+    height: u32,
+    is_opaque: bool,
+) -> Vec<u32> {
     // This formula is from the IMG_texture_compression_pvrtc extension spec.
     let expected_size = if is_2bit {
         (width.max(16) as usize * height.max(8) as usize * 2).div_ceil(8)
@@ -342,5 +367,15 @@ pub fn decode_pvrtc(pvrtc_data: &[u8], is_2bit: bool, width: u32, height: u32) -
         assert_eq!(consumed_size as usize, expected_size);
         rgba8_data.set_len(rgba8_word_count);
     };
+
+    if is_opaque {
+        // Force alpha to fully opaque (the high byte of each little-endian
+        // RGBA8 word). The RGB-PVRTC base internal format is RGB, so the
+        // sampled alpha must be 1.0 on real hardware.
+        for word in rgba8_data.iter_mut() {
+            *word |= 0xFF00_0000;
+        }
+    }
+
     rgba8_data
 }


### PR DESCRIPTION
## Problem

Many games — including LEGO Ninjago: Rise of the Snakes (`com.lego.riseofthesnakes`) — show a **black screen while audio plays and touch/clicks still register**. The log always contains:

```
touchHLE::gles::gles1_native: GLES1Native: GL_IMG_texture_compression_pvrtc NOT advertised by host driver (PVRTC textures will be software-decoded to RGBA before upload on this driver)
```

That message itself is benign (the host GPU just lacks hardware PVRTC, so we software-decode). The real bug is in **what we decode to**.

## Root cause

The log shows the app uploading `glCompressedTexImage2D(512x512, internalformat=0x8c00, …)`. `0x8c00` is `COMPRESSED_RGB_PVRTC_4BPPV1_IMG` — the **opaque RGB** PVRTC variant.

Per the [`IMG_texture_compression_pvrtc`](https://registry.khronos.org/OpenGL/extensions/IMG/IMG_texture_compression_pvrtc.txt) spec, the `COMPRESSED_RGB_PVRTC_*` formats have a **base internal format of RGB**, so sampling them must yield **alpha = 1.0** — exactly what real PowerVR / Apple hardware does.

But PVRTC blocks can individually opt into a "transparent colour mode" *regardless* of the requested internal format, so `PVRTDecompress` emits real per-texel alpha even for the RGB formats. The software path then uploaded that buffer as `GL_RGBA`, preserving the stray sub-255 (often 0) alpha. With the app's `GL_BLEND` + `GL_SRC_ALPHA` enabled (the trace confirms `BLEND=1 (src=0x0302 dst=0x0303)`), opaque textures blend away to nothing → **black screen, but audio and input keep working**.

I verified this empirically against the in-tree `PVRTDecompress.cpp`: an RGB-PVRTC block using transparent mode decodes to `0x00ffffff` (alpha 0); forcing opaque yields `0xffffffff`.

## Fix

- `decode_pvrtc_with_alpha(... is_opaque)` forces alpha to `0xFF` for the opaque RGB variants (`decode_pvrtc` keeps the old behaviour as a thin wrapper).
- `try_decode_pvrtc` now detects `COMPRESSED_RGB_PVRTC_{2,4}BPPV1_IMG`, decodes with forced-opaque alpha, and uploads with a `GL_RGB` base internal format so the host driver enforces alpha = 1.0. `COMPRESSED_RGBA_PVRTC_*` is unchanged.
- The direct `CompressedTexSubImage2D` decode path in `gles1_on_gl2` gets the same opaque handling.

Because every backend (gles1_native, gles1_on_gl2, gles2_native, gles3_native, gles3_on_gl3) routes through the shared `try_decode_pvrtc`, the fix covers all of them.

No stubs — this is the real decode/upload path. `cargo check --lib` passes (only pre-existing warnings).
