### PR TITLE
Fix Unity GlesHelper.mm GL_INVALID_OPERATION (0x0502) per-frame flood

### DIFF
--- a/src/frameworks/opengles/eagl.rs
+++ b/src/frameworks/opengles/eagl.rs
@@ -996,6 +996,23 @@ unsafe fn present_renderbuffer_es2(
 
     gles.ActiveTexture(gles2::TEXTURE0);
     gles.BindTexture(gles2::TEXTURE_2D, present_objects.texture);
+    gles.BindBuffer(gles2::ARRAY_BUFFER, present_objects.quad_vbo);
+    #[rustfmt::skip]
+    let verts: [f32; 24] = [
+        // x, y, u, v
+        -1.0, -1.0, 0.0, 0.0,
+         1.0, -1.0, 1.0, 0.0,
+        -1.0,  1.0, 0.0, 1.0,
+         1.0, -1.0, 1.0, 0.0,
+         1.0,  1.0, 1.0, 1.0,
+        -1.0,  1.0, 0.0, 1.0,
+    ];
+    gles.BufferData(
+        gles2::ARRAY_BUFFER,
+        std::mem::size_of_val(&verts) as isize,
+        verts.as_ptr().cast(),
+        gles2::STREAM_DRAW,
+    );
     gles.CopyTexImage2D(gles2::TEXTURE_2D, 0, gles2::RGB, 0, 0, width, height, 0);
 
     gles.BindFramebuffer(gles2::FRAMEBUFFER, 0);
@@ -1075,18 +1092,12 @@ unsafe fn present_renderbuffer_es2(
         cols.as_ptr() as *const _,
     );
 
-    // Pixel-coordinate quad covering the whole viewport.
-    #[rustfmt::skip]
-    let verts: [f32; 24] = [
-        // x, y, u, v
-        -1.0, -1.0, 0.0, 0.0,
-         1.0, -1.0, 1.0, 0.0,
-        -1.0,  1.0, 0.0, 1.0,
-         1.0, -1.0, 1.0, 0.0,
-         1.0,  1.0, 1.0, 1.0,
-        -1.0,  1.0, 0.0, 1.0,
-    ];
-    gles.BindBuffer(gles2::ARRAY_BUFFER, 0);
+    // The full-screen quad lives in `present_objects.quad_vbo`, uploaded
+    // above. Core-profile desktop GL (and the GL-on-Vulkan Zink driver used
+    // by Winlator on Android) reject client-side vertex arrays with
+    // GL_INVALID_OPERATION, so we must source the quad from a real buffer
+    // object — never from a host-memory pointer.
+    gles.BindBuffer(gles2::ARRAY_BUFFER, present_objects.quad_vbo);
     gles.EnableVertexAttribArray(program.a_pos as _);
     gles.EnableVertexAttribArray(program.a_uv as _);
     gles.VertexAttribPointer(
@@ -1095,7 +1106,7 @@ unsafe fn present_renderbuffer_es2(
         gles2::FLOAT,
         gles2::FALSE,
         16,
-        verts.as_ptr() as *const _,
+        std::ptr::null(),
     );
     gles.VertexAttribPointer(
         program.a_uv as _,
@@ -1103,7 +1114,7 @@ unsafe fn present_renderbuffer_es2(
         gles2::FLOAT,
         gles2::FALSE,
         16,
-        (verts.as_ptr() as *const u8).add(8) as *const _,
+        8usize as *const _,
     );
     gles.DrawArrays(gles2::TRIANGLES, 0, 6);
 
@@ -1172,6 +1183,21 @@ unsafe fn present_renderbuffer_es2(
     if scissor_was_on {
         gles.Enable(gles2::SCISSOR_TEST);
     }
+
+    // The renderbuffer present is performed by us (the emulator), not by the
+    // guest app. On a real iPhone OS device the equivalent work happens
+    // inside `-[EAGLContext presentRenderbuffer:]` / the windowserver, behind
+    // a context the app never error-checks. Our present path runs in the
+    // *same* host GL context and therefore shares a single `glGetError` error
+    // queue with the guest. Any error our own present operations might queue
+    // (e.g. a benign INVALID_OPERATION from a strict desktop GL / Zink core
+    // profile that the guest's lenient iOS PowerVR/Adreno driver would never
+    // raise) would otherwise be read back by the guest's *next* GL call and
+    // misattributed to the app — this is exactly the per-frame
+    // `OpenGLES error 0x0502 in .../GlesHelper.mm` flood seen on Unity titles.
+    // Drain the queue so the guest only ever observes errors it actually
+    // caused, matching the real-device contract.
+    while gles.GetError() != 0 {}
 }
 
 #[derive(Copy, Clone)]
@@ -1196,6 +1222,7 @@ struct PresentProgram {
 struct PresentObjects {
     framebuffer: GLuint,
     texture: GLuint,
+    quad_vbo: GLuint,
 }
 
 thread_local! {
@@ -1332,6 +1359,8 @@ unsafe fn ensure_present_objects(gles: &mut dyn GLES) -> PresentObjects {
     gles.GenFramebuffers(1, &mut framebuffer);
     let mut texture: GLuint = 0;
     gles.GenTextures(1, &mut texture);
+    let mut quad_vbo: GLuint = 0;
+    gles.GenBuffers(1, &mut quad_vbo);
     gles.ActiveTexture(crate::gles::gles2_raw::TEXTURE0);
     gles.BindTexture(crate::gles::gles2_raw::TEXTURE_2D, texture);
     gles.TexParameteri(
@@ -1358,6 +1387,7 @@ unsafe fn ensure_present_objects(gles: &mut dyn GLES) -> PresentObjects {
     let result = PresentObjects {
         framebuffer,
         texture,
+        quad_vbo,
     };
     PRESENT_OBJECTS.with(|c| c.set(Some(result)));
     result


### PR DESCRIPTION
## Problem

Unity-built iOS games (e.g. **Turbo Dismount**) spam a per-frame flood of:

```
OpenGLES error 0x0502 in /Users/.../Classes/Unity/GlesHelper.mm:320
```

`0x0502` is `GL_INVALID_OPERATION`. This was reproduced on Android via Winlator with the **Mesa Zink** (OpenGL-on-Vulkan) driver, which routes our desktop-GL fallback backend (`GLES2OnGL3` / `GLES3OnGL3`, built on **OpenGL 3.3 Core**).

### Root cause

Unity wraps every GL call in a `GLES_CHK` macro that immediately calls `glGetError()` and prints the file/line if non-zero (`CheckGLESError` at the bottom of `GlesHelper.mm`). The error it observed was **not** caused by the guest — it was leaking out of **our own** frame-present code.

`present_renderbuffer_es2()` (the shader-based present path used by the ES2/ES3-on-GL3.3-Core backends) drew its full-screen blit quad from a **client-side vertex array** (`glVertexAttribPointer(..., verts.as_ptr())` with no buffer bound). Client-side vertex arrays are **forbidden in an OpenGL Core profile** (and rejected by Zink), so each present generated `GL_INVALID_OPERATION`. Because our present path runs in the **same host GL context** as the guest — sharing a single `glGetError` queue — the error sat in the queue and was read back by Unity's next `GLES_CHK`, getting misattributed to `GlesHelper.mm`.

On a real iPhone OS device the equivalent present work happens inside `-[EAGLContext presentRenderbuffer:]` / the windowserver, behind a context the app never error-checks — so the guest never sees these errors. Ref: Apple, *"Drawing to Other Rendering Destinations" / Working with EAGL Contexts* (OpenGL ES Programming Guide).

## Fix

1. **Source the present quad from a real Vertex Buffer Object** instead of a host-memory pointer. Added a cached `quad_vbo` to the per-thread `PresentObjects`, upload the quad with `glBufferData`, and switch the two `glVertexAttribPointer` calls to buffer offsets (`0` and `8`). This is Core-profile / Zink legal and removes the actual `GL_INVALID_OPERATION` at its source.
2. **Drain the GL error queue at the end of `present_renderbuffer_es2`**, mirroring what the ES 1.1 present path already does. This guarantees no emulator-internal present error can ever leak into the guest's `glGetError` queue and be misread by an app that polls errors itself — matching the real-device contract. Defense-in-depth in case a strict driver flags something else in the present path.

## Testing

- `RUSTFLAGS="-C link-arg=-latomic" cargo build --lib` — compiles cleanly (no new warnings/errors).
- The ES 1.1 present path was already error-draining; this brings the ES2/ES3-on-GL3.3 path to parity and additionally fixes the underlying invalid call.