### PR TITLE
mem: wrap guest pointer arithmetic mod 2^32 instead of panicking (fixes NFS: Most Wanted crash)

### DIFF
--- a/src/mem.rs
+++ b/src/mem.rs
@@ -150,11 +150,16 @@ impl<T, const MUT: bool> std::ops::Add<GuestUSize> for Ptr<T, MUT> {
     fn add(self, other: GuestUSize) -> Self {
         let size: GuestUSize = guest_size_of::<T>();
         assert_ne!(size, 0);
-        Self::from_bits(
-            self.to_bits()
-                .checked_add(other.checked_mul(size).unwrap())
-                .unwrap(),
-        )
+        // Real 32-bit ARM (ARMv7-A) computes addresses modulo 2^32: pointer
+        // arithmetic silently wraps around the 4 GiB address space and never
+        // traps. A fault only occurs when the resulting address is actually
+        // *accessed* and points at unmapped memory — and `Mem::bytes_at` /
+        // `bytes_at_mut` already handle that case gracefully via the null/OOB
+        // stub pages. Using `checked_*().unwrap()` here instead turned benign
+        // (or already-corrupt, but guest-local) pointer math into a hard host
+        // panic, e.g. when a buggy guest computes `base + (size_t)(-N)` while
+        // building a `std::string`/shader buffer. Mirror the hardware: wrap.
+        Self::from_bits(self.to_bits().wrapping_add(other.wrapping_mul(size)))
     }
 }
 impl<T, const MUT: bool> std::ops::AddAssign<GuestUSize> for Ptr<T, MUT> {
@@ -168,11 +173,10 @@ impl<T, const MUT: bool> std::ops::Sub<GuestUSize> for Ptr<T, MUT> {
     fn sub(self, other: GuestUSize) -> Self {
         let size: GuestUSize = guest_size_of::<T>();
         assert_ne!(size, 0);
-        Self::from_bits(
-            self.to_bits()
-                .checked_sub(other.checked_mul(size).unwrap())
-                .unwrap(),
-        )
+        // See the note on `Add` above: 32-bit ARM address arithmetic wraps
+        // modulo 2^32 and never traps, so subtracting past zero must wrap
+        // rather than panic the host.
+        Self::from_bits(self.to_bits().wrapping_sub(other.wrapping_mul(size)))
     }
 }
 impl<T, const MUT: bool> std::ops::SubAssign<GuestUSize> for Ptr<T, MUT> {
@@ -1075,5 +1079,22 @@ mod mem_tests {
             mem.write(p, 0xAB);
             assert_eq!(mem.read(p.cast_const()), 0xAB);
         }
+    }
+
+    #[test]
+    fn ptr_arithmetic_wraps_modulo_2_32() {
+        // Real 32-bit ARM computes addresses modulo 2^32 and never traps on
+        // the arithmetic itself. These cases previously panicked the host via
+        // `checked_*().unwrap()`; they must now wrap like the hardware.
+        let near_top: Ptr<u8, true> = Ptr::from_bits(0xFFFF_FFFB);
+        assert_eq!((near_top + 0x10).to_bits(), 0x0000_000B);
+
+        let low: Ptr<u8, true> = Ptr::from_bits(0x0000_0004);
+        assert_eq!((low - 0x10).to_bits(), 0xFFFF_FFF4);
+
+        // Element-sized arithmetic (u32 = 4 bytes) must also wrap rather than
+        // overflow when the multiplied offset exceeds the address space.
+        let p: Ptr<u32, true> = Ptr::from_bits(0xFFFF_FFF0);
+        assert_eq!((p + 0x8).to_bits(), 0x0000_0010);
     }
 }


### PR DESCRIPTION
## Problem

Need for Speed: Most Wanted (and other games) crash the emulator with a hard host panic:

```
touchHLE::libc::stdlib: Hack! malloc passed negative size 0xfffffff0 (-16). Allocating 16 bytes instead.
Panic at src/mem.rs:156:18: called `Option::unwrap()` on a `None` value
```

`src/mem.rs:156` is `Ptr::add`. The crashing thread had `R2 = 0xffffffec (-20)`, `R4/R10 = 0xfffffffb (-5)` — the guest was computing a pointer from a corrupted/negative size while building a shader / `std::string` buffer (the same code path that produces the preceding `memmove with likely-negative size` and `Shader 1 compile failed: no main() function` warnings in the log).

`Ptr::add` and `Ptr::sub` used `checked_add` / `checked_mul` / `checked_sub` with `.unwrap()`, so **any** guest pointer arithmetic that overflowed or underflowed the 32-bit address space aborted the entire VM.

## Why this is wrong (per the architecture)

On real 32-bit ARM (ARMv7-A, which this game targets — `armv7` / `opengles-2`), address calculations are performed **modulo 2³²** and never trap. A fault only occurs when the resulting address is actually *accessed* and points at unmapped memory.

touchHLE already models that correctly: `Mem::bytes_at` / `Mem::bytes_at_mut` redirect null-page and out-of-bounds accesses to stub / write-sink pages instead of panicking. So the *arithmetic* must wrap; only the *access* should be guarded (and it already is).

## Fix

Switch `Ptr::add` / `Ptr::sub` to `wrapping_add` / `wrapping_sub` / `wrapping_mul`, mirroring the hardware. No stubs, no fake values — this is the real ARM pointer semantics.

Added a regression test `ptr_arithmetic_wraps_modulo_2_32` covering wrap-around at both ends of the address space and element-sized (>1 byte) arithmetic.

## Testing

- `cargo build` (with `RUSTFLAGS="-C link-arg=-latomic"`) — succeeds.
- `cargo test --lib` — 58 passed, 0 failed.
- No new clippy warnings in the changed region.

The fatal panic that ended the NFS: Most Wanted session no longer aborts the emulator; execution continues into the access-level guards that already exist.
