### PR TITLE
Export missing MediaPlayer constants

### DIFF
--- a/src/frameworks/media_player.rs
+++ b/src/frameworks/media_player.rs
@@ -29,7 +29,12 @@ pub const DYLIB: crate::dyld::HostDylib = crate::dyld::HostDylib {
         media_query::CLASSES,
         mf_mail_compose_view_controller::CLASSES,
     ],
-    constant_exports: &[movie_player::CONSTANTS, music_player::CONSTANTS],
+    constant_exports: &[
+        movie_player::CONSTANTS,
+        music_player::CONSTANTS,
+        media_library::CONSTANTS,
+        media_playlist::CONSTANTS,
+    ],
     function_exports: &[],
 };
 

--- a/src/frameworks/media_player/media_library.rs
+++ b/src/frameworks/media_player/media_library.rs
@@ -12,11 +12,21 @@
 //! library — no songs, playlists, or artists. This prevents apps from
 //! crashing when they call methods on the returned object.
 
+use crate::dyld::{ConstantExports, HostConstant};
 use crate::objc::{id, msg, msg_class, objc_classes, ClassExports, HostObject, NSZonePtr};
 
 /// Host object for MPMediaLibrary — just a marker (empty library).
 struct MPMediaLibraryHostObject;
 impl HostObject for MPMediaLibraryHostObject {}
+
+pub const MPMediaLibraryDidChangeNotification: &str = "MPMediaLibraryDidChangeNotification";
+
+pub const CONSTANTS: ConstantExports = &[
+    (
+        "_MPMediaLibraryDidChangeNotification",
+        HostConstant::NSString(MPMediaLibraryDidChangeNotification),
+    ),
+];
 
 pub const CLASSES: ClassExports = objc_classes! {
 

--- a/src/frameworks/media_player/media_playlist.rs
+++ b/src/frameworks/media_player/media_playlist.rs
@@ -5,7 +5,51 @@
  */
 //! `MPMediaPlaylist`.
 
+use crate::dyld::{ConstantExports, HostConstant};
 use crate::objc::{objc_classes, ClassExports};
+
+// `MPMediaPlaylist` property keys. Per Apple's "Playlist property keys"
+// documentation (`MPMediaPlaylist.h`), each of these is an `NSString *`
+// constant whose value is the documented Cocoa property name:
+// https://developer.apple.com/documentation/mediaplayer/playlist-property-keys?language=objc
+pub const MPMediaPlaylistPropertyAuthorDisplayName: &str = "authorDisplayName";
+pub const MPMediaPlaylistPropertyName: &str = "name";
+pub const MPMediaPlaylistPropertyDescriptionText: &str = "descriptionText";
+pub const MPMediaPlaylistPropertyPersistentID: &str = "persistentID";
+pub const MPMediaPlaylistPropertyPlaylistAttributes: &str = "playlistAttributes";
+pub const MPMediaPlaylistPropertyCloudGlobalID: &str = "cloudGlobalID";
+pub const MPMediaPlaylistPropertySeedItems: &str = "seedItems";
+
+pub const CONSTANTS: ConstantExports = &[
+    (
+        "_MPMediaPlaylistPropertyAuthorDisplayName",
+        HostConstant::NSString(MPMediaPlaylistPropertyAuthorDisplayName),
+    ),
+    (
+        "_MPMediaPlaylistPropertyName",
+        HostConstant::NSString(MPMediaPlaylistPropertyName),
+    ),
+    (
+        "_MPMediaPlaylistPropertyDescriptionText",
+        HostConstant::NSString(MPMediaPlaylistPropertyDescriptionText),
+    ),
+    (
+        "_MPMediaPlaylistPropertyPersistentID",
+        HostConstant::NSString(MPMediaPlaylistPropertyPersistentID),
+    ),
+    (
+        "_MPMediaPlaylistPropertyPlaylistAttributes",
+        HostConstant::NSString(MPMediaPlaylistPropertyPlaylistAttributes),
+    ),
+    (
+        "_MPMediaPlaylistPropertyCloudGlobalID",
+        HostConstant::NSString(MPMediaPlaylistPropertyCloudGlobalID),
+    ),
+    (
+        "_MPMediaPlaylistPropertySeedItems",
+        HostConstant::NSString(MPMediaPlaylistPropertySeedItems),
+    ),
+];
 
 pub const CLASSES: ClassExports = objc_classes! {
 


### PR DESCRIPTION
Fixes missing MediaPlayer exports for GTA: SA / touchHLE logs.

- Exports _MPMediaLibraryDidChangeNotification from MediaPlayer
- Exports _MPMediaPlaylistPropertyName and related playlist keys
- Registers the new constant exports in the MediaPlayer dylib

Verified by building locally with cargo: finished successfully.