### PR TITLE
uikit: restore Geometry Dash landscape touch remap

### DIFF
--- a/src/frameworks/uikit/ui_touch.rs
+++ b/src/frameworks/uikit/ui_touch.rs
@@ -77,7 +77,7 @@ fn touchhle_cocos_is_gl_or_game_view_name(class_name: &str) -> bool {
 fn touchhle_should_use_landscape_touch_remap(env: &Environment) -> bool {
     match env.bundle.bundle_identifier() {
         // Confirmed landscape Source/Cocos games.
-        "at.source.veggie1" | "at.source.potato3D" | "at.source.potpan" => true,
+        "at.source.veggie1" | "at.source.potato3D" | "at.source.potpan" | "com.robtop.geometryjump" => true,
 
         // TomatoZombie is native portrait.
         "at.source.tomzom" => false,
@@ -91,22 +91,8 @@ fn touchhle_should_use_landscape_touch_remap(env: &Environment) -> bool {
 }
 
 fn should_remap_touch_location_for_view(env: &mut Environment, view: id) -> bool {
-    match env.bundle.bundle_identifier() {
-        // Confirmed/wip landscape Source/Cocos games.
-        "at.source.veggie1" | "at.source.potato3D" | "at.source.potpan" => return true,
-
-        // TomatoZombie is native portrait.
-        "at.source.tomzom" => return false,
-
-        _ => {}
-    }
-
-    if std::env::var_os("TOUCHHLE_TOUCH_LOCATION_PORTRAIT_TO_LANDSCAPE").is_some()
-        || std::env::var_os("TOUCHHLE_COCOS_TOUCH_REMAP").is_some()
-        || std::env::var_os("TOUCHHLE_UNITY_TOUCH_REMAP").is_some()
-        || std::env::var_os("TOUCHHLE_ENGINE_TOUCH_REMAP").is_some()
-    {
-        return true;
+    if !touchhle_should_use_landscape_touch_remap(env) {
+        return false;
     }
 
     if view == nil { return false; }
@@ -132,7 +118,7 @@ fn touchhle_cocos_remap_point(env: &mut Environment, view: id, point: CGPoint) -
     let (target_w, target_h) = touchhle_cocos_target_size();
     let mode = std::env::var("TOUCHHLE_TOUCH_MODE").unwrap_or_else(|_| {
         match env.bundle.bundle_identifier() {
-            "at.source.veggie1" | "at.source.potato3D" | "at.source.potpan" => "scale".to_string(),
+            "at.source.veggie1" | "at.source.potato3D" | "at.source.potpan" | "com.robtop.geometryjump" => "scale".to_string(),
             _ => std::env::var("TOUCHHLE_COCOS_TOUCH_MODE")
                 .or_else(|_| std::env::var("TOUCHHLE_UNITY_TOUCH_MODE"))
                 .or_else(|_| std::env::var("TOUCHHLE_ENGINE_TOUCH_MODE"))


### PR DESCRIPTION
## Проблема

Geometry Dash 1.0 (`com.robtop.geometryjump`) — это cocos2d-игра в ландшафтной ориентации. Она отрисовывается и играет звук, но **касания игнорируются** (тапы попадают не в те виджеты либо не срабатывают вовсе).

Игра рисует своё OpenGL-меню в системе координат 480×320 (landscape) — так же, как другие уже подтверждённо рабочие Source/Cocos-игры (Captain Tomato, Potato Story, Potato Panic).

## Причина

Ранний фикс (`14ac892`) уже добавлял `com.robtop.geometryjump` в набор игр с landscape-ремапом касаний. Но позже, когда пер-игровой список был свёрнут в общую детекцию Cocos-вью, эта запись потерялась. В итоге GD перестала получать переремапленные координаты, и `-[UITouch locationInView:]` возвращал портретные 320×480-координаты — тапы уходили мимо кнопок.

## Что делает этот PR

- Возвращает `com.robtop.geometryjump` в `touchhle_should_use_landscape_touch_remap` и в дефолт режима `scale`.
- Упрощает `should_remap_touch_location_for_view`: теперь гейт зависит от общего решения о landscape-ремапе плюс наличия реальной GL/игровой вью.

Ремап затрагивает **только** координату, возвращаемую из `-[UITouch locationInView:]`, и **не** трогает hit-testing — это соответствует документированной модели Apple (`hitTest:withEvent:` / `pointInside:withEvent:` работают в обычном UIKit-пространстве, а игра получает ожидаемую ей систему координат).

Важно: в отличие от отменённой попытки (`0c40c98`), этот PR **не** возвращает поведение «отбрасывать касание при неудачном hitTest» — именно оно тогда всё ломало.

## Проверка

- `RUSTFLAGS="-C link-arg=-latomic" cargo build` — успешно (менялся только `src/frameworks/uikit/ui_touch.rs`).
- Изменение точечное, повторяет уже работающий путь для соседних Cocos-игр.

Документация Apple:
- UITouch.location(in:) — возвращает точку в системе координат заданной вью.
- UIView hitTest:withEvent: / pointInside:withEvent: — семантика hit-testing (farthest descendant, содержащая точку).
