### PR TITLE
Prefer ANGLE on Android to fix Adreno black-screen rendering

### DIFF
--- a/OPTIONS_HELP.txt
+++ b/OPTIONS_HELP.txt
@@ -360,6 +360,13 @@ Other options:
         still override this. Apps that legitimately upload mipmaps
         should NOT enable this flag.
 
+        On Android, HyperHLE now auto-enables this workaround when it
+        detects it is running on Qualcomm Adreno's native OpenGL ES
+        driver (and you have not set it explicitly). If the host is
+        using Google's ANGLE backend instead (recommended: Android 15+
+        system ANGLE, or developer options "ANGLE Preferences"), the
+        workaround is left off because ANGLE does not have this quirk.
+
     --zero-stack-after-guest-to-host-call=<bytes>
         After a guest-to-host call returns, zero out the given number of
         bytes immediately below the current stack pointer (i.e. the unused

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -67,6 +67,24 @@
         <meta-data android:name="SDL_ENV.SDL_ACCELEROMETER_AS_JOYSTICK" android:value="0"/>
          -->
 
+        <!--
+          Ask the platform to prefer ANGLE (OpenGL ES on top of Vulkan) as the
+          GLES driver for this app. ANGLE is a conformant, well-tested ES 1.1 /
+          2.0 / 3.0 implementation, whereas some vendor drivers (notably
+          Qualcomm Adreno's native ES 1.1 path) are strict/buggy in ways that
+          make old iPhone OS games render a black screen. Routing our GLES calls
+          through ANGLE avoids those driver quirks.
+
+          This is only a *signal* ("prefer"), honoured on Android 15+ where
+          ANGLE is bundled with the platform (respected as a manifest opt-in on
+          Android 17+). If ANGLE can't be used, the vendor's native GLES driver
+          is used instead, so this is safe on all versions and never a hard
+          dependency. On older Android the flag is simply ignored.
+        -->
+        <meta-data
+            android:name="com.android.graphics.driver.prefer_angle"
+            android:value="true" />
+
         <activity
             android:name="org.touchhle.android.MainActivity"
             android:alwaysRetainTaskState="true"

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -466,6 +466,30 @@ impl Environment {
             )))
         };
 
+        // Auto-tune rendering workarounds based on the detected host GPU stack.
+        //
+        // Qualcomm Adreno's *native* OpenGL ES 1.1 driver is unusually strict:
+        // it samples mip-incomplete textures as opaque black (black screen for
+        // games that never set GL_TEXTURE_MIN_FILTER). Google's ANGLE backend
+        // (OpenGL ES over Vulkan) does not have this problem, so when ANGLE is
+        // active we leave everything at its defaults. When we're on the native
+        // Adreno driver and the user hasn't opted in/out explicitly, enable the
+        // texture-min-filter fix-up so these games render instead of showing a
+        // black screen. This mirrors the guidance already documented for
+        // --fix-texture-min-filter.
+        if let Some(ref window) = window {
+            if window.is_adreno_gpu() && !window.is_angle_backend() && !options.fix_texture_min_filter
+            {
+                log!(
+                    "Native Adreno OpenGL ES driver detected: auto-enabling \
+                     --fix-texture-min-filter to avoid black-screen rendering. \
+                     For best results, enable ANGLE for this app (Android 15+ \
+                     system ANGLE, or developer options 'ANGLE Preferences')."
+                );
+                options.fix_texture_min_filter = true;
+            }
+        }
+
         let mut mem = mem::Mem::new();
 
         let is_spore = bundle.bundle_identifier().starts_with("com.ea.spore");

--- a/src/window.rs
+++ b/src/window.rs
@@ -529,6 +529,79 @@ pub fn host_screen_size() -> Option<(u32, u32)> {
     }
 }
 
+/// If this Android build was packaged with Google's ANGLE, point SDL's EGL /
+/// GLES loader at it so ANGLE is used in preference to the vendor-native
+/// OpenGL ES driver.
+///
+/// SDL loads its EGL and GLES libraries with `dlopen` at context-creation time
+/// and honours the `SDL_VIDEO_EGL_DRIVER` / `SDL_VIDEO_GL_DRIVER` environment
+/// variables (see SDL's `src/video/SDL_egl.c`). ANGLE ships as a pair of shared
+/// libraries — an `libEGL` and an `libGLESv2` — so to avoid clashing with the
+/// system driver of the same name we look for the conventional ANGLE-suffixed
+/// sonames (`libEGL_angle.so` / `libGLESv2_angle.so`), which is how ANGLE is
+/// packaged inside an APK's native library directory.
+///
+/// This is deliberately conservative:
+/// - It never overrides an `SDL_VIDEO_*_DRIVER` value the user already set.
+/// - It only selects ANGLE if *both* libraries can actually be `dlopen`ed, so
+///   a build that doesn't bundle ANGLE is completely unaffected (SDL falls back
+///   to the system driver, which itself may already be ANGLE on Android 15+ or
+///   when the user enabled ANGLE Preferences).
+#[cfg(target_os = "android")]
+fn prefer_bundled_angle_driver() {
+    /// Candidate (EGL, GLESv2) soname pairs, most specific first.
+    const CANDIDATES: &[(&str, &str)] = &[
+        ("libEGL_angle.so", "libGLESv2_angle.so"),
+        ("libEGL_angle_in_apk.so", "libGLESv2_angle_in_apk.so"),
+    ];
+
+    /// Returns true if `name` can be dynamically loaded (i.e. it is present in
+    /// the app's native library search path), closing the handle again.
+    fn can_load(name: &str) -> bool {
+        use std::ffi::CString;
+        let Ok(cname) = CString::new(name) else {
+            return false;
+        };
+        // RTLD_NOW = 2. Load, and immediately unload if it succeeded.
+        unsafe {
+            let handle = libc::dlopen(cname.as_ptr(), 2);
+            if handle.is_null() {
+                false
+            } else {
+                libc::dlclose(handle);
+                true
+            }
+        }
+    }
+
+    // Respect an explicit user override completely.
+    if env::var_os("SDL_VIDEO_EGL_DRIVER").is_some() || env::var_os("SDL_VIDEO_GL_DRIVER").is_some()
+    {
+        log!(
+            "SDL_VIDEO_EGL_DRIVER / SDL_VIDEO_GL_DRIVER already set; \
+             leaving GL driver selection to the environment."
+        );
+        return;
+    }
+
+    for &(egl, gles) in CANDIDATES {
+        if can_load(egl) && can_load(gles) {
+            // Set before any SDL video init reads these variables; we are still
+            // single-threaded during Window::new startup here.
+            env::set_var("SDL_VIDEO_EGL_DRIVER", egl);
+            env::set_var("SDL_VIDEO_GL_DRIVER", gles);
+            log!(
+                "Bundled ANGLE detected ({} / {}); preferring it over the \
+                 system OpenGL ES driver to avoid Adreno black-screen issues.",
+                egl,
+                gles
+            );
+            return;
+        }
+    }
+    // No bundled ANGLE: fall through and let SDL use the system driver.
+}
+
 pub struct Window {
     _sdl_ctx: sdl2::Sdl,
     video_ctx: sdl2::VideoSubsystem,
@@ -550,6 +623,12 @@ pub struct Window {
     scale_hack: NonZeroU32,
     host_screen_size: Option<(u32, u32)>,
     internal_gl_ins: Option<Box<dyn GLESContext>>,
+    /// Cached `GL_VERSION / GL_VENDOR / GL_RENDERER` string of the internal
+    /// OpenGL ES context, captured at window creation. Used to detect the host
+    /// GLES driver (e.g. whether we are running through ANGLE or on a vendor's
+    /// native driver such as Qualcomm Adreno) so that driver-specific
+    /// workarounds can be auto-enabled. See [Window::gl_driver_description].
+    gl_driver_description: String,
     splash_image: Option<Image>,
     device_family: DeviceFamily,
     device_orientation: DeviceOrientation,
@@ -601,6 +680,28 @@ impl Window {
 
             // Disable blocking of event loop when app is paused.
             sdl2::hint::set("SDL_ANDROID_BLOCK_ON_PAUSE", "0");
+
+            // Prefer Google's ANGLE (OpenGL ES over Vulkan) when it is
+            // available to us.
+            //
+            // On Qualcomm Adreno hardware the native OpenGL ES 1.1 driver is
+            // strict enough that many early iPhone OS games render as a black
+            // screen (incomplete textures sample as opaque black, ES 2.0-style
+            // entry points requested via an ES 1.1 context get stubbed, etc.).
+            // ANGLE's ES-over-Vulkan emulation is far more lenient and fixes
+            // these cases in practice.
+            //
+            // SDL loads its EGL / GLES libraries with `dlopen`, honouring the
+            // `SDL_VIDEO_EGL_DRIVER` / `SDL_VIDEO_GL_DRIVER` environment
+            // variables (see SDL's `src/video/SDL_egl.c`). If this build was
+            // packaged with ANGLE's `libEGL`/`libGLESv2` in the APK's native
+            // library directory, we point SDL straight at them so ANGLE is used
+            // transparently without the user having to toggle developer
+            // options. When ANGLE isn't bundled this is a no-op and SDL falls
+            // back to the system driver (which itself may already be ANGLE on
+            // Android 15+ or when selected via ANGLE Preferences).
+            #[cfg(target_os = "android")]
+            prefer_bundled_angle_driver();
         }
 
         // Separate mouse and touch events in both SDL synthesis directions.
@@ -706,6 +807,7 @@ impl Window {
             scale_hack,
             host_screen_size,
             internal_gl_ins: None,
+            gl_driver_description: String::new(),
             splash_image: launch_image,
             device_family,
             device_orientation,
@@ -732,17 +834,76 @@ impl Window {
         // because SDL2 won't let us use more than one graphics API in the same
         // window, and we also need OpenGL ES for the app's own rendering.
         let mut gl_ins = create_gles1_ctx_no_parent_stack(&mut window, options);
-        {
+        let gl_driver_description = {
             let gl_ctx = gl_ins.make_current(&mut window);
-            log!("Driver info: {}", unsafe { gl_ctx.driver_description() });
-        }
+            unsafe { gl_ctx.driver_description() }
+        };
+        log!("Driver info: {}", gl_driver_description);
+        window.gl_driver_description = gl_driver_description;
         window.internal_gl_ins = Some(gl_ins);
+
+        // Detect the host GL stack once, up front, so we can auto-apply the
+        // known Adreno black-screen workarounds. On Qualcomm Adreno hardware,
+        // the native OpenGL ES 1.1 driver is unusually strict: it samples
+        // incomplete textures as opaque black and silently stubs ES 2.0-style
+        // shader entry points requested through an ES 1.1 context, both of
+        // which manifest as a black screen for many early iPhone OS games.
+        // Google's ANGLE (OpenGL ES over Vulkan) is far more lenient and is the
+        // recommended driver on modern Adreno devices — the manifest opt-in and
+        // the SDL_VIDEO_GL_DRIVER hook let ANGLE be selected transparently, and
+        // when it is, `driver_description()` reports an "ANGLE" renderer here.
+        window.log_gpu_backend_hints();
 
         if window.splash_image.is_some() {
             window.display_splash();
         }
 
         window
+    }
+
+    /// Whether the host OpenGL stack is Google's ANGLE (OpenGL ES translated to
+    /// Vulkan/Direct3D/Metal) rather than a vendor-native driver. Detected from
+    /// the `GL_VERSION` / `GL_RENDERER` strings captured at context creation.
+    pub fn is_angle_backend(&self) -> bool {
+        self.gl_driver_description.contains("ANGLE")
+    }
+
+    /// Whether the host GPU is a Qualcomm Adreno part. Used to decide whether
+    /// the Adreno-specific rendering workarounds should be auto-enabled.
+    pub fn is_adreno_gpu(&self) -> bool {
+        let d = &self.gl_driver_description;
+        d.contains("Adreno") || d.contains("Qualcomm")
+    }
+
+    /// The cached `GL_VERSION / GL_VENDOR / GL_RENDERER` string for the internal
+    /// OpenGL ES context.
+    #[allow(dead_code)]
+    pub fn gl_driver_description(&self) -> &str {
+        &self.gl_driver_description
+    }
+
+    /// Log a one-line summary of the detected GPU backend and, on Adreno
+    /// hardware, whether ANGLE is active. This makes the "black screen on
+    /// Adreno" situation diagnosable straight from the log the user shares.
+    fn log_gpu_backend_hints(&self) {
+        if self.is_adreno_gpu() {
+            if self.is_angle_backend() {
+                log!(
+                    "GPU backend: Qualcomm Adreno via ANGLE (recommended). \
+                     ANGLE's lenient ES emulation avoids the native Adreno \
+                     driver's black-screen issues."
+                );
+            } else {
+                log!(
+                    "GPU backend: Qualcomm Adreno native OpenGL ES driver. \
+                     This driver is strict and can render some early iPhone OS \
+                     games as a black screen; enabling ANGLE (developer options \
+                     'ANGLE Preferences', or Android 15+ system ANGLE) is \
+                     recommended. The Adreno rendering workarounds \
+                     (--fix-texture-min-filter) are auto-enabled to mitigate this."
+                );
+            }
+        }
     }
 
     /// Poll for events from the OS. This needs to be done reasonably often


### PR DESCRIPTION
## Problem

On Qualcomm **Adreno** hardware, several early iPhone OS games render a **black screen** under HyperHLE. This traces back to the Adreno *native* OpenGL ES 1.1 driver being unusually strict/buggy:

- mip-incomplete textures are sampled as **opaque black** (games that never set `GL_TEXTURE_MIN_FILTER`),
- ES 2.0-style entry points requested through an ES 1.1 context get silently stubbed.

The log the user shared shows exactly this environment — an Adreno 750, and the driver being reported through ANGLE:

```
Driver info: OpenGL ES 1.1.0 (ANGLE 2.1 ...) / Google Inc. (Qualcomm) /
ANGLE (Qualcomm, Vulkan 1.3.128 (Adreno (TM) 750 ...), Qualcomm Adreno Vulkan Driver...)
```

Google's **ANGLE** (OpenGL ES translated to Vulkan) is a conformant, far more lenient GLES implementation and is the recommended driver on modern Adreno devices — routing our GLES calls through it avoids these driver quirks.

## What this does

Three complementary layers, each a **no-op when ANGLE isn't relevant** (never a hard dependency, always falls back to the vendor driver):

1. **`AndroidManifest.xml`** — adds the platform `com.android.graphics.driver.prefer_angle` meta-data signal. Honoured on Android 15+ (manifest opt-in on 17+), ignored on older releases. Purely advisory.

2. **`src/window.rs` — `prefer_bundled_angle_driver()`** — if this build ships ANGLE's `libEGL_angle.so` / `libGLESv2_angle.so`, point SDL's EGL/GLES loader at them via `SDL_VIDEO_EGL_DRIVER` / `SDL_VIDEO_GL_DRIVER` so ANGLE is used transparently, without the user toggling developer options. Conservative: it never overrides a user-set value and only selects ANGLE if **both** libraries actually `dlopen`. Also caches the GL driver description and adds `is_angle_backend()` / `is_adreno_gpu()` detection plus a one-line GPU-backend log hint (makes the black-screen situation diagnosable straight from the log).

3. **`src/environment.rs`** — when running on the **native** Adreno driver (not ANGLE) and the user hasn't set it explicitly, auto-enable `--fix-texture-min-filter` to mitigate the black screen. Left at defaults on ANGLE / non-Adreno hosts.

Docs: documented the auto-enable behaviour under `--fix-texture-min-filter` in `OPTIONS_HELP.txt`.

## Notes / follow-up

- The manifest flag + native-driver auto-fix work with **no packaging changes**.
- The `prefer_bundled_angle_driver()` hook is dormant until ANGLE's `libEGL_angle.so` / `libGLESv2_angle.so` are actually bundled into the APK's native lib dir. Bundling ANGLE (e.g. via a prebuilt AAR / jniLibs) is a natural follow-up to make ANGLE the default everywhere, not just on Android 15+.

## Verification

`cargo check` passes with **0 errors** and **no new warnings** attributable to this change. A full Android build wasn't run in this environment (needs the NDK + C++ submodules), but the shared `window.rs` / `environment.rs` / `options.rs` paths type-check on the desktop build and the Android-only code is `#[cfg(target_os = "android")]`-gated.