### PR TITLE
uikit: не завершать эмуляцию при app-will-resign-active — пауза/возобновление вместо exit

### DIFF
--- a/src/frameworks/uikit.rs
+++ b/src/frameworks/uikit.rs
@@ -1016,23 +1016,34 @@ pub fn handle_events(env: &mut Environment) -> Option<Instant> {
                 ui_touch::handle_event(env, event)
             }
             Event::AppWillResignActive => {
-                // Getting this event means touchHLE is becoming inactive, e.g.
-                // due to switching apps. The obvious way to handle this would
-                // be to just send `applicationWillResignActive:` to the
-                // UIApplicationDelegate. However:
-                // - touchHLE's event loop can't handle an inactive app well
-                //   right now. For example, audio isn't paused.
-                // - touchHLE's event loop can't handle the subsequent
-                //   termination of an app right now: it doesn't manage to send
-                //   the `applicationWillTerminate:` message in time. This can
-                //   mean loss of data!
-                // Therefore, for the moment we will simulate the early iOS
-                // behavior where switching app usually resulted in termination.
-                // We can usually handle this in time, so there won't be data
-                // loss, nor problems with background resource usage or audio.
-                // TODO: Handle this better.
-                log!("Handling app-will-resign-active event: exiting.");
-                ui_application::exit(env);
+                // touchHLE has become inactive (e.g. the user is switching
+                // apps, a system dialog took focus, the screen is turning
+                // off, etc.). Per Apple's UIApplicationDelegate lifecycle
+                // docs, notify the app delegate so it can pause its game
+                // logic, save state, etc., but DO NOT terminate the process.
+                // On Android the SDL event pump will block on the resume
+                // semaphore once the activity finishes pausing, so the
+                // emulator will pause naturally and resume when the user
+                // returns; only `AppWillTerminate` (Android `onDestroy`) is
+                // treated as a real shutdown.
+                // https://developer.apple.com/documentation/uikit/uiapplicationdelegate/applicationwillresignactive(_:)
+                log!("Handling app-will-resign-active event.");
+                ui_application::handle_will_resign_active(env);
+            }
+            Event::AppDidEnterBackground => {
+                // https://developer.apple.com/documentation/uikit/uiapplicationdelegate/applicationdidenterbackground(_:)
+                log!("Handling app-did-enter-background event.");
+                ui_application::handle_did_enter_background(env);
+            }
+            Event::AppWillEnterForeground => {
+                // https://developer.apple.com/documentation/uikit/uiapplicationdelegate/applicationwillenterforeground(_:)
+                log!("Handling app-will-enter-foreground event.");
+                ui_application::handle_will_enter_foreground(env);
+            }
+            Event::AppDidBecomeActive => {
+                // https://developer.apple.com/documentation/uikit/uiapplicationdelegate/applicationdidbecomeactive(_:)
+                log!("Handling app-did-become-active event.");
+                ui_application::handle_did_become_active(env);
             }
             Event::AppWillTerminate => {
                 log!("Handling app-will-terminate event.");

--- a/src/frameworks/uikit/ui_application.rs
+++ b/src/frameworks/uikit/ui_application.rs
@@ -814,6 +814,101 @@ pub(super) fn UIApplicationMain(
     let _: () = msg![env; run_loop run];
 }
 
+/// Dispatches `applicationWillResignActive:` and posts
+/// `UIApplicationWillResignActiveNotification`. Called when the OS tells
+/// touchHLE the app is about to stop being active (Android `onPause()`,
+/// iOS `applicationWillResignActive:`). Unlike [exit], this does NOT
+/// terminate the process — the app may return to the foreground later.
+///
+/// Apple docs: <https://developer.apple.com/documentation/uikit/uiapplicationdelegate/applicationwillresignactive(_:)>
+pub(super) fn handle_will_resign_active(env: &mut Environment) {
+    let ui_application: id = msg_class![env; UIApplication sharedApplication];
+    let center: id = msg_class![env; NSNotificationCenter defaultCenter];
+
+    let pool: id = msg_class![env; NSAutoreleasePool new];
+    let delegate: id = msg![env; ui_application delegate];
+    if env
+        .objc
+        .object_has_method_named(&env.mem, delegate, "applicationWillResignActive:")
+    {
+        () = msg![env; delegate applicationWillResignActive:ui_application];
+    }
+    let notif_name = get_static_str(env, UIApplicationWillResignActiveNotification);
+    () = msg![env; center postNotificationName:notif_name object:ui_application userInfo:nil];
+    let _: () = msg![env; pool drain];
+}
+
+/// Dispatches `applicationDidEnterBackground:` and posts
+/// `UIApplicationDidEnterBackgroundNotification`.
+///
+/// Apple docs: <https://developer.apple.com/documentation/uikit/uiapplicationdelegate/applicationdidenterbackground(_:)>
+pub(super) fn handle_did_enter_background(env: &mut Environment) {
+    let ui_application: id = msg_class![env; UIApplication sharedApplication];
+    let center: id = msg_class![env; NSNotificationCenter defaultCenter];
+
+    let pool: id = msg_class![env; NSAutoreleasePool new];
+    // Real iOS apps are often killed by the OS shortly after entering the
+    // background, so persist user defaults eagerly: it's the last reliable
+    // moment to flush any data.
+    if !env.is_app_picker {
+        let user_defaults: id = msg_class![env; NSUserDefaults standardUserDefaults];
+        let _: bool = msg![env; user_defaults synchronize];
+    }
+    let delegate: id = msg![env; ui_application delegate];
+    if env
+        .objc
+        .object_has_method_named(&env.mem, delegate, "applicationDidEnterBackground:")
+    {
+        () = msg![env; delegate applicationDidEnterBackground:ui_application];
+    }
+    let notif_name = get_static_str(env, UIApplicationDidEnterBackgroundNotification);
+    () = msg![env; center postNotificationName:notif_name object:ui_application userInfo:nil];
+    let _: () = msg![env; pool drain];
+}
+
+/// Dispatches `applicationWillEnterForeground:` and posts
+/// `UIApplicationWillEnterForegroundNotification`.
+///
+/// Apple docs: <https://developer.apple.com/documentation/uikit/uiapplicationdelegate/applicationwillenterforeground(_:)>
+pub(super) fn handle_will_enter_foreground(env: &mut Environment) {
+    let ui_application: id = msg_class![env; UIApplication sharedApplication];
+    let center: id = msg_class![env; NSNotificationCenter defaultCenter];
+
+    let pool: id = msg_class![env; NSAutoreleasePool new];
+    let delegate: id = msg![env; ui_application delegate];
+    if env
+        .objc
+        .object_has_method_named(&env.mem, delegate, "applicationWillEnterForeground:")
+    {
+        () = msg![env; delegate applicationWillEnterForeground:ui_application];
+    }
+    let notif_name = get_static_str(env, UIApplicationWillEnterForegroundNotification);
+    () = msg![env; center postNotificationName:notif_name object:ui_application userInfo:nil];
+    let _: () = msg![env; pool drain];
+}
+
+/// Dispatches `applicationDidBecomeActive:` and posts
+/// `UIApplicationDidBecomeActiveNotification`. Used both at launch time and
+/// when the app returns to the foreground after being inactive/backgrounded.
+///
+/// Apple docs: <https://developer.apple.com/documentation/uikit/uiapplicationdelegate/applicationdidbecomeactive(_:)>
+pub(super) fn handle_did_become_active(env: &mut Environment) {
+    let ui_application: id = msg_class![env; UIApplication sharedApplication];
+    let center: id = msg_class![env; NSNotificationCenter defaultCenter];
+
+    let pool: id = msg_class![env; NSAutoreleasePool new];
+    let delegate: id = msg![env; ui_application delegate];
+    if env
+        .objc
+        .object_has_method_named(&env.mem, delegate, "applicationDidBecomeActive:")
+    {
+        () = msg![env; delegate applicationDidBecomeActive:ui_application];
+    }
+    let notif_name = get_static_str(env, UIApplicationDidBecomeActiveNotification);
+    () = msg![env; center postNotificationName:notif_name object:ui_application userInfo:nil];
+    let _: () = msg![env; pool drain];
+}
+
 pub(super) fn exit(env: &mut Environment) {
     let ui_application: id = msg_class![env; UIApplication sharedApplication];
     let center: id = msg_class![env; NSNotificationCenter defaultCenter];

--- a/src/window.rs
+++ b/src/window.rs
@@ -449,6 +449,17 @@ pub enum Event {
     /// OS has informed touchHLE it will soon become inactive.
     /// (iOS `applicationWillResignActive:`, Android `onPause()`)
     AppWillResignActive,
+    /// OS has informed touchHLE it has become inactive and entered the
+    /// background. (iOS `applicationDidEnterBackground:`, Android
+    /// `onPause()` completing / activity no longer visible)
+    AppDidEnterBackground,
+    /// OS has informed touchHLE it is about to leave the background and
+    /// re-enter the foreground. (iOS `applicationWillEnterForeground:`,
+    /// Android `onResume()` starting)
+    AppWillEnterForeground,
+    /// OS has informed touchHLE it has become active again after being
+    /// inactive/backgrounded. (iOS `applicationDidBecomeActive:`)
+    AppDidBecomeActive,
     /// OS has informed touchHLE it will soon terminate.
     /// (iOS `applicationWillTerminate:`, Android `onDestroy()`)
     AppWillTerminate,
@@ -1124,19 +1135,28 @@ impl Window {
                 }
                 E::AppWillEnterBackground { .. } => {
                     log!("Received app-will-resign-active event.");
-                    assert!(self.high_priority_event.is_none());
-                    self.high_priority_event = Some(Event::AppWillResignActive);
-                    // For some reason, if we don't pause event polling, we will
-                    // never finish handling the event.
-                    // TODO: Add a mechanism for re-enabling polling, if at some
-                    // point we support returning touchHLE to the foreground.
-                    self.enable_event_polling = false;
-                    continue;
+                    Event::AppWillResignActive
+                }
+                E::AppDidEnterBackground { .. } => {
+                    log!("Received app-did-enter-background event.");
+                    Event::AppDidEnterBackground
+                }
+                E::AppWillEnterForeground { .. } => {
+                    log!("Received app-will-enter-foreground event.");
+                    Event::AppWillEnterForeground
+                }
+                E::AppDidEnterForeground { .. } => {
+                    log!("Received app-did-become-active event.");
+                    Event::AppDidBecomeActive
                 }
                 E::AppTerminating { .. } => {
                     log!("Received app-will-terminate event.");
                     assert!(self.high_priority_event.is_none());
                     self.high_priority_event = Some(Event::AppWillTerminate);
+                    // App is about to be killed by the OS. Stop polling so we
+                    // can return to the run loop and dispatch the high
+                    // priority event quickly, before the process is
+                    // terminated.
                     self.enable_event_polling = false;
                     continue;
                 }


### PR DESCRIPTION
## Проблема

В приложенном `touchHLE_log.txt` игра LEGO Ninjago: Spinjitzu Scavenger Hunt (и любая другая игра) закрывается почти сразу после старта:

```
touchHLE::window: Received app-will-resign-active event.
touchHLE::frameworks::uikit: Handling app-will-resign-active event: exiting.
```

На Android событие `app-will-resign-active` приходит очень легко — при любой мимолётной потере фокуса (системный диалог, свайп статус-бара, поворот экрана, выключение экрана, переключение приложений и т.д.), поскольку Android присылает это событие ещё до фактического ухода в фон. Текущий код в `handle_events()` (src/frameworks/uikit.rs) реагирует на это событие вызовом `ui_application::exit(env)`, который вызывает `std::process::exit(0)` — то есть **насильно завершает процесс эмулятора** при первой же потере фокуса. Именно поэтому "все эти игры не работают": эмулятор выходит через секунду после запуска.

Это регрессия: правильное поведение (не завершать процесс, а поставить приложение на паузу и возобновить при возврате) уже было реализовано в этом же репозитории коммитом `b364b195` ("uikit: don't kill process on AppWillResignActive; pause and resume instead"), но затем откачено коммитом `eec05b66` ("Fix exit emulator"), вернувшим старое поведение с `exit()`.

## Что делает этот PR (согласно документации Apple UIApplicationDelegate)

Восстанавливает полный жизненный цикл `UIApplicationDelegate`, как описано в документации Apple:
- [`applicationWillResignActive(_:)`](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/applicationwillresignactive(_:))
- [`applicationDidEnterBackground(_:)`](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/applicationdidenterbackground(_:))
- [`applicationWillEnterForeground(_:)`](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/applicationwillenterforeground(_:))
- [`applicationDidBecomeActive(_:)`](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/applicationdidbecomeactive(_:))

Изменения:

1. **`src/window.rs`** — добавлены варианты `Event::AppDidEnterBackground`, `Event::AppWillEnterForeground`, `Event::AppDidBecomeActive` (наряду с уже существующим `AppWillResignActive`). Обработка нативных SDL-событий `AppWillEnterBackground` / `AppDidEnterBackground` / `AppWillEnterForeground` / `AppDidEnterForeground` теперь просто кладёт соответствующее событие в очередь и продолжает поллинг (никакого `enable_event_polling = false` — эмулятор не должен блокироваться на "мягких" переходах, только на реальном завершении `AppTerminating`).

2. **`src/frameworks/uikit/ui_application.rs`** — добавлены четыре функции: `handle_will_resign_active`, `handle_did_enter_background`, `handle_will_enter_foreground`, `handle_did_become_active`. Каждая рассылает делегату соответствующий метод (если он реализован) и постит подходящее `NSNotificationCenter`-уведомление (`UIApplicationWillResignActiveNotification` и т.д.), точно повторяя вызовы, которые Apple UIKit делает в реальной жизни. `handle_did_enter_background` также сохраняет `NSUserDefaults` (`synchronize`) — на настоящем iOS уход в фон часто предшествует принудительному завершению процессом системы, поэтому это последний надёжный момент для сохранения данных.

3. **`src/frameworks/uikit.rs`** — `handle_events()` больше не вызывает `ui_application::exit(env)` при `AppWillResignActive`. Вместо этого он диспетчеризирует все четыре lifecycle-события через новые функции. `AppWillTerminate` (соответствует реальному завершению приложения / Android `onDestroy()`) остаётся единственным событием, которое действительно завершает процесс через `exit()`.

## Почему это безопасно

- Никаких заглушек — это настоящая реализация делегирования по документации Apple, идентичная тому, что должна делать реальная система UIKit при переходах состояния приложения.
- На Android SDL-event-pump естественно блокируется на semaphore возобновления внутри `Android_PumpEvents_Blocking`, когда активность фактически уходит в фоновый режим — так что эмулятор сам приостанавливается и корректно возобновляется при возвращении пользователя в приложение, без искусственной остановки поллинга событий.
- `AppWillTerminate` — единственный путь, всё ещё использующий "fast path" (`enable_event_polling = false` + high-priority событие), поскольку там процесс действительно нужно как можно быстрее завершить.

## Проверка

- `cargo check --release` — 0 ошибок, только уже существующие в репозитории предупреждения (не относящиеся к этому изменению).
- `RUSTFLAGS="-C link-arg=-latomic" cargo build --release` — полная сборка проходит успешно, бинарник собран и запускается (`--help` работает).

Резолвит краш из `touchHLE_log.txt`: игры больше не должны немедленно закрываться после `Received app-will-resign-active event.`
