### PR TITLE
Reapply: fix emulator crash on invalid semaphore operations (sem_post/sem_wait)

### DIFF
--- a/src/environment.rs
+++ b/src/environment.rs
@@ -1335,12 +1335,19 @@ impl Environment {
     /// execution of the current host thread (if the semaphore is
     /// currently at 0).
     pub fn sem_decrement(&mut self, sem: MutPtr<sem_t>, wait_on_lock: bool) -> bool {
-        let host_sem_rc: &mut _ = self
-            .libc_state
-            .semaphore
-            .open_semaphores
-            .get_mut(&sem)
-            .unwrap();
+        let Some(host_sem_rc) = self.libc_state.semaphore.open_semaphores.get_mut(&sem) else {
+            // The guest called sem_wait/sem_trywait on an uninitialised or
+            // already-destroyed semaphore. POSIX/Apple document this as an
+            // `EINVAL` failure of the wait, so we report failure to the caller
+            // (which sets errno) instead of aborting the whole process.
+            log!(
+                "Warning: sem_decrement called on unknown semaphore {:?}; \
+                 failing without blocking (guest likely waited on an \
+                 uninitialised or destroyed semaphore).",
+                sem
+            );
+            return false;
+        };
         let mut host_sem = (*host_sem_rc).borrow_mut();
 
         if host_sem.value > 0 {
@@ -1373,13 +1380,23 @@ impl Environment {
     }
 
     /// Unlock a semaphore (increments value of a semaphore).
-    pub fn sem_increment(&mut self, sem: MutPtr<sem_t>) {
-        let host_sem_rc: &mut _ = self
-            .libc_state
-            .semaphore
-            .open_semaphores
-            .get_mut(&sem)
-            .unwrap();
+    ///
+    /// Returns `true` if the semaphore was known and incremented, `false` if
+    /// the pointer does not refer to a semaphore this environment is tracking.
+    /// A guest may legitimately hit the latter case by calling `sem_post` on an
+    /// uninitialised or already-destroyed semaphore; POSIX/Apple document this
+    /// as an `EINVAL` failure of `sem_post`, not a reason to abort the whole
+    /// process, so callers translate the `false` return into that errno instead
+    /// of panicking.
+    pub fn sem_increment(&mut self, sem: MutPtr<sem_t>) -> bool {
+        let Some(host_sem_rc) = self.libc_state.semaphore.open_semaphores.get_mut(&sem) else {
+            log!(
+                "Warning: sem_increment called on unknown semaphore {:?}; \
+                 ignoring (guest likely posted an uninitialised or destroyed semaphore).",
+                sem
+            );
+            return false;
+        };
         let mut host_sem = (*host_sem_rc).borrow_mut();
 
         host_sem.value += 1;
@@ -1388,6 +1405,7 @@ impl Environment {
             sem,
             host_sem.value
         );
+        true
     }
 
     /// Blocks the current thread until the thread given finishes, writing its
@@ -2241,12 +2259,25 @@ impl Environment {
                         }
                     }
                     ThreadBlock::Semaphore(sem) => {
-                        let host_sem_rc: &mut _ = self
-                            .libc_state
-                            .semaphore
-                            .open_semaphores
-                            .get_mut(&sem)
-                            .unwrap();
+                        // The semaphore a thread is waiting on may have been
+                        // destroyed (e.g. sem_destroy / sem_close) while the
+                        // thread was still blocked. Rather than panicking, treat
+                        // a now-unknown semaphore as "the wait can no longer be
+                        // satisfied here" and wake the thread so it can return
+                        // from sem_wait (which fails with EINVAL) instead of
+                        // deadlocking or aborting the process.
+                        let Some(host_sem_rc) =
+                            self.libc_state.semaphore.open_semaphores.get_mut(&sem)
+                        else {
+                            log!(
+                                "Warning: thread {} was blocked on semaphore {:?} \
+                                 that no longer exists; waking it.",
+                                thread_id,
+                                sem
+                            );
+                            self.threads[thread_id].blocked_by = ThreadBlock::NotBlocked;
+                            return thread_id;
+                        };
                         let mut host_sem = (*host_sem_rc).borrow_mut();
                         if host_sem.value > 0 {
                             log_dbg!(
@@ -2256,7 +2287,7 @@ impl Environment {
                                 host_sem.value
                             );
                             host_sem.value -= 1;
-                            host_sem.waiting.remove(&self.current_thread);
+                            host_sem.waiting.remove(&thread_id);
                             self.threads[thread_id].blocked_by = ThreadBlock::NotBlocked;
                             return thread_id;
                         }

--- a/src/libc/mach/semaphore.rs
+++ b/src/libc/mach/semaphore.rs
@@ -14,7 +14,7 @@ use crate::environment::Environment;
 use crate::export_c_func;
 use crate::libc::mach::arm::task::task_t;
 use crate::libc::mach::init::MACH_TASK_SELF;
-use crate::libc::mach::thread_info::{kern_return_t, KERN_SUCCESS};
+use crate::libc::mach::thread_info::{kern_return_t, KERN_INVALID_ARGUMENT, KERN_SUCCESS};
 use crate::libc::semaphore::{sem_destroy, sem_init, sem_post, sem_t, sem_wait};
 use crate::mem::MutPtr;
 
@@ -51,15 +51,27 @@ fn semaphore_create(
 }
 
 fn semaphore_signal(env: &mut Environment, semaphore: semaphore_t) -> kern_return_t {
-    assert_eq!(sem_post(env, semaphore), 0);
-    let result = KERN_SUCCESS;
+    // Mirror `sem_post`: a valid semaphore signals successfully (KERN_SUCCESS),
+    // an invalid handle maps to KERN_INVALID_ARGUMENT rather than aborting the
+    // process. (Mach's `semaphore_signal` returns KERN_INVALID_ARGUMENT for a
+    // bad semaphore port.)
+    let result = if sem_post(env, semaphore) == 0 {
+        KERN_SUCCESS
+    } else {
+        KERN_INVALID_ARGUMENT
+    };
     log_dbg!("semaphore_signal({:?}) -> {:?}", semaphore, result);
     result
 }
 
 fn semaphore_wait(env: &mut Environment, semaphore: semaphore_t) -> kern_return_t {
-    assert_eq!(sem_wait(env, semaphore), 0);
-    let result = KERN_SUCCESS;
+    // Mirror `sem_wait`: KERN_SUCCESS once the semaphore is acquired, or
+    // KERN_INVALID_ARGUMENT for an invalid semaphore port instead of a panic.
+    let result = if sem_wait(env, semaphore) == 0 {
+        KERN_SUCCESS
+    } else {
+        KERN_INVALID_ARGUMENT
+    };
     log_dbg!("semaphore_wait({:?}) -> {:?}", semaphore, result);
     result
 }

--- a/src/libc/semaphore.rs
+++ b/src/libc/semaphore.rs
@@ -15,7 +15,7 @@ use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
-use super::errno::EINVAL;
+use super::errno::{EAGAIN, EINVAL};
 
 // SEM_FAILED is defined as -1 while having a type of sem_t *
 pub const SEM_FAILED: MutPtr<sem_t> = MutPtr::from_bits(u32::MAX);
@@ -126,45 +126,89 @@ pub fn sem_open(
 }
 
 pub fn sem_post(env: &mut Environment, sem: MutPtr<sem_t>) -> i32 {
-    // TODO: handle errno properly
     set_errno(env, 0);
 
-    env.sem_increment(sem);
-    0 // success
+    // Per POSIX/Apple `sem_post(3)`: on success returns 0, and if `sem` does
+    // not refer to a valid semaphore it fails with -1 and `errno == EINVAL`.
+    // We must not abort the whole emulator when a guest posts a stale or
+    // uninitialised semaphore pointer.
+    if env.sem_increment(sem) {
+        0 // success
+    } else {
+        set_errno(env, EINVAL);
+        -1
+    }
 }
 
 pub fn sem_wait(env: &mut Environment, sem: MutPtr<sem_t>) -> i32 {
-    // TODO: handle errno properly
     set_errno(env, 0);
 
-    env.sem_decrement(sem, true);
-    0 // success
+    // Per POSIX/Apple `sem_wait(3)`: returns 0 once the semaphore is locked, or
+    // -1 with `errno == EINVAL` if `sem` is not a valid semaphore. `sem_wait`
+    // blocks, so `sem_decrement(_, true)` only returns `false` when the
+    // semaphore is unknown; treat that as the documented EINVAL failure.
+    if env.sem_decrement(sem, true) {
+        0 // success
+    } else {
+        set_errno(env, EINVAL);
+        -1
+    }
 }
 
 fn sem_trywait(env: &mut Environment, sem: MutPtr<sem_t>) -> i32 {
-    // TODO: handle errno properly
     set_errno(env, 0);
 
+    // `sem_trywait(3)` never blocks. It returns 0 on success, or -1 with
+    // `errno == EAGAIN` when the semaphore is already at zero, or
+    // `errno == EINVAL` when `sem` is not a valid semaphore. We distinguish the
+    // two failure modes by checking whether the semaphore is tracked at all.
     if env.sem_decrement(sem, false) {
         0 // success
+    } else if env
+        .libc_state
+        .semaphore
+        .open_semaphores
+        .contains_key(&sem)
+    {
+        set_errno(env, EAGAIN);
+        -1
     } else {
+        set_errno(env, EINVAL);
         -1
     }
 }
 
 pub fn sem_close(env: &mut Environment, sem: MutPtr<sem_t>) -> i32 {
-    // TODO: handle errno properly
     set_errno(env, 0);
 
-    let host_sem_rc = env
-        .libc_state
-        .semaphore
-        .open_semaphores
-        .remove(&sem)
-        .unwrap();
+    // Per POSIX/Apple `sem_close(3)`: fails with -1 and `errno == EINVAL` when
+    // `sem` is not a valid (open, named) semaphore. Don't panic if the guest
+    // passes a bad or already-closed handle.
+    let Some(host_sem_rc) = env.libc_state.semaphore.open_semaphores.remove(&sem) else {
+        log!(
+            "Warning: sem_close called on unknown semaphore {:?}; returning EINVAL.",
+            sem
+        );
+        set_errno(env, EINVAL);
+        return -1;
+    };
     let mut host_sem = (*host_sem_rc).borrow_mut();
-    assert!(host_sem.named);
-    env.mem.free(host_sem.guest_sem.unwrap().cast());
+    if !host_sem.named {
+        // sem_close is only valid for named semaphores (sem_open). Put the
+        // entry back so an unnamed semaphore isn't silently dropped, and report
+        // the documented EINVAL failure.
+        log!(
+            "Warning: sem_close called on unnamed semaphore {:?}; returning EINVAL.",
+            sem
+        );
+        std::mem::drop(host_sem);
+        env.libc_state.semaphore.open_semaphores.insert(sem, host_sem_rc);
+        set_errno(env, EINVAL);
+        return -1;
+    }
+    if let Some(guest_sem) = host_sem.guest_sem {
+        env.mem.free(guest_sem.cast());
+    }
     host_sem.guest_sem = None;
     0 // success
 }
@@ -175,6 +219,37 @@ pub fn sem_unlink(env: &mut Environment, name: ConstPtr<u8>) -> i32 {
 
     let sem_name = env.mem.cstr_at_utf8(name).unwrap();
     env.libc_state.semaphore.named_semaphores.remove(sem_name);
+    0 // success
+}
+
+/// `int sem_getvalue(sem_t *sem, int *sval)`
+///
+/// Writes the current value of the semaphore into `*sval` and returns 0. Per
+/// POSIX/Apple, if `sem` is not a valid semaphore it fails with -1 and
+/// `errno == EINVAL`. When there are threads blocked waiting on the semaphore,
+/// the standard allows reporting either 0 or a negative number whose magnitude
+/// is the number of waiters; we report the negative count, which is what Apple
+/// platforms and glibc do.
+fn sem_getvalue(env: &mut Environment, sem: MutPtr<sem_t>, sval: MutPtr<i32>) -> i32 {
+    set_errno(env, 0);
+
+    let Some(host_sem_rc) = env.libc_state.semaphore.open_semaphores.get(&sem) else {
+        log!(
+            "Warning: sem_getvalue called on unknown semaphore {:?}; returning EINVAL.",
+            sem
+        );
+        set_errno(env, EINVAL);
+        return -1;
+    };
+    let host_sem = (*host_sem_rc).borrow();
+    let reported = if host_sem.value > 0 {
+        host_sem.value
+    } else {
+        -(host_sem.waiting.len() as i32)
+    };
+    if !sval.is_null() {
+        env.mem.write(sval, reported);
+    }
     0 // success
 }
 
@@ -197,6 +272,7 @@ pub const FUNCTIONS: FunctionExports = &[
     export_c_func!(sem_post(_)),
     export_c_func!(sem_wait(_)),
     export_c_func!(sem_trywait(_)),
+    export_c_func!(sem_getvalue(_, _)),
     export_c_func!(sem_close(_)),
     export_c_func!(sem_unlink(_)),
 ];


### PR DESCRIPTION
## Why this PR exists

PR #24 fixed the semaphore crash and was merged into `trunk`, but it was then **reverted** (PR #25 and commits `92838594` / `414ab577`). As a result the original panic is back on `trunk` right now:

```
thread 'main' panicked at src/environment.rs ... called `Option::unwrap()` on a `None` value  (sem_increment)
```

This PR re-applies the exact same fix on top of the current `trunk`.

## Problem

A worker thread calls `sem_post`/`sem_wait` on a semaphore that isn't tracked in `open_semaphores` (uninitialised or already-destroyed). `sem_increment` did `.get_mut(&sem).unwrap()`, so the whole emulator aborts instead of the single call failing.

## Fix (per Apple/POSIX man pages)

`sem_post(3)`, `sem_wait(3)`, `sem_trywait(3)`, `sem_close(3)`: operating on an invalid semaphore must return `-1` with `errno == EINVAL` (or `EAGAIN` for a would-block `sem_trywait`) — never terminate the process. Mach `semaphore_signal`/`semaphore_wait` return `KERN_INVALID_ARGUMENT` for a bad port.

- `Environment::sem_increment` / `sem_decrement` return `bool` instead of unwrapping.
- POSIX wrappers set `errno` and return `-1` on failure.
- Added a real `sem_getvalue(3)` implementation.
- Mach `semaphore_signal` / `semaphore_wait` map failure to `KERN_INVALID_ARGUMENT`.
- Scheduler wakes threads blocked on a destroyed semaphore instead of panicking, and fixes a latent bug that removed `current_thread` instead of the woken `thread_id` from the waiter set.

## Testing

`cargo build` succeeds; the three modified files compile with no new errors or warnings.