### PR TITLE
Fix Rush Rally 2 launch crash: implement GL_EXT_occlusion_query_boolean

### DIFF
--- a/src/frameworks/opengles/gles_guest.rs
+++ b/src/frameworks/opengles/gles_guest.rs
@@ -424,7 +424,7 @@ fn glGetString(env: &mut Environment, name: GLenum) -> ConstPtr<GLubyte> {
             // desktop GL; reference it by numeric literal so we don't have
             // to pull in the ES 2.0 enum table here.
             0x8B8C => b"OpenGL ES GLSL ES 1.00",
-            gles11::EXTENSIONS => b"GL_APPLE_framebuffer_multisample GL_APPLE_texture_max_level GL_EXT_debug_label GL_EXT_discard_framebuffer GL_EXT_texture_filter_anisotropic GL_EXT_texture_lod_bias GL_IMG_read_format GL_IMG_texture_compression_pvrtc GL_IMG_texture_format_BGRA8888 GL_OES_depth24 GL_OES_depth_texture GL_OES_packed_depth_stencil GL_OES_rgb8_rgba8 GL_OES_standard_derivatives GL_OES_texture_float GL_OES_texture_half_float GL_OES_vertex_array_object GL_OES_vertex_half_float ",
+            gles11::EXTENSIONS => b"GL_APPLE_framebuffer_multisample GL_APPLE_texture_max_level GL_EXT_debug_label GL_EXT_discard_framebuffer GL_EXT_occlusion_query_boolean GL_EXT_texture_filter_anisotropic GL_EXT_texture_lod_bias GL_IMG_read_format GL_IMG_texture_compression_pvrtc GL_IMG_texture_format_BGRA8888 GL_OES_depth24 GL_OES_depth_texture GL_OES_packed_depth_stencil GL_OES_rgb8_rgba8 GL_OES_standard_derivatives GL_OES_texture_float GL_OES_texture_half_float GL_OES_vertex_array_object GL_OES_vertex_half_float ",
             _ => b"Unknown",
         }
     };
@@ -4281,6 +4281,44 @@ fn glGetQueryObjectuiv(env: &mut Environment, id: GLuint, pname: GLenum, params:
     });
 }
 
+// -- Boolean occlusion queries (GL_EXT_occlusion_query_boolean) --
+// The `*EXT` entry points are the OpenGL ES 2.0 form of the boolean occlusion
+// query API. They are semantically identical to the ES 3.0 core query objects
+// (only the accepted `target`s differ: GL_ANY_SAMPLES_PASSED_EXT and
+// GL_ANY_SAMPLES_PASSED_CONSERVATIVE_EXT), so each `*EXT` wrapper forwards to
+// the same backend trait method as its core counterpart. iPhone OS games such
+// as Rush Rally 2 link against these symbols directly, so they must be exported
+// or the dynamic linker leaves the guest's function pointer null and the app
+// jumps to a null address on launch.
+// Reference: https://registry.khronos.org/OpenGL/extensions/EXT/EXT_occlusion_query_boolean.txt
+fn glGenQueriesEXT(env: &mut Environment, n: GLsizei, ids: MutPtr<GLuint>) {
+    glGenQueries(env, n, ids)
+}
+
+fn glDeleteQueriesEXT(env: &mut Environment, n: GLsizei, ids: ConstPtr<GLuint>) {
+    glDeleteQueries(env, n, ids)
+}
+
+fn glIsQueryEXT(env: &mut Environment, id: GLuint) -> GLboolean {
+    glIsQuery(env, id)
+}
+
+fn glBeginQueryEXT(env: &mut Environment, target: GLenum, id: GLuint) {
+    glBeginQuery(env, target, id)
+}
+
+fn glEndQueryEXT(env: &mut Environment, target: GLenum) {
+    glEndQuery(env, target)
+}
+
+fn glGetQueryivEXT(env: &mut Environment, target: GLenum, pname: GLenum, params: MutPtr<GLint>) {
+    glGetQueryiv(env, target, pname, params)
+}
+
+fn glGetQueryObjectuivEXT(env: &mut Environment, id: GLuint, pname: GLenum, params: MutPtr<GLuint>) {
+    glGetQueryObjectuiv(env, id, pname, params)
+}
+
 // -- Sampler objects --
 fn glGenSamplers(env: &mut Environment, count: GLsizei, samplers: MutPtr<GLuint>) {
     with_ctx_and_mem(env, |gles, mem| unsafe {
@@ -5439,6 +5477,14 @@ pub const FUNCTIONS: FunctionExports = &[
     export_c_func!(glEndQuery(_)),
     export_c_func!(glGetQueryiv(_, _, _)),
     export_c_func!(glGetQueryObjectuiv(_, _, _)),
+    // GL_EXT_occlusion_query_boolean (OpenGL ES 2.0 boolean occlusion queries)
+    export_c_func!(glGenQueriesEXT(_, _)),
+    export_c_func!(glDeleteQueriesEXT(_, _)),
+    export_c_func!(glIsQueryEXT(_)),
+    export_c_func!(glBeginQueryEXT(_, _)),
+    export_c_func!(glEndQueryEXT(_)),
+    export_c_func!(glGetQueryivEXT(_, _, _)),
+    export_c_func!(glGetQueryObjectuivEXT(_, _, _)),
     export_c_func!(glGenSamplers(_, _)),
     export_c_func!(glDeleteSamplers(_, _)),
     export_c_func!(glIsSampler(_)),

--- a/src/gles/gl_bindings/build.rs
+++ b/src/gles/gl_bindings/build.rs
@@ -95,6 +95,14 @@ fn main() {
             // of degrading to a no-op resolve (which leaves the drawable
             // empty → black screen).
             "GL_APPLE_framebuffer_multisample",
+            // Boolean occlusion queries (glGenQueriesEXT / glBeginQueryEXT /
+            // glGetQueryObjectuivEXT etc.). Real iPhone OS ES 2.0 drivers on
+            // the PowerVR SGX advertise this extension, and games such as
+            // Rush Rally 2 link against these `*EXT` symbols directly. Without
+            // the bindings the guest symbol binds to null and the game jumps
+            // to a null pointer on launch.
+            // Reference: https://registry.khronos.org/OpenGL/extensions/EXT/EXT_occlusion_query_boolean.txt
+            "GL_EXT_occlusion_query_boolean",
         ],
     )
     .write_bindings(GlobalGenerator, &mut file)

--- a/src/gles/gles2_native.rs
+++ b/src/gles/gles2_native.rs
@@ -1453,6 +1453,53 @@ impl GLES for GLES2Native<'_> {
         gles2::IsVertexArrayOES(array)
     }
 
+    // Boolean occlusion queries (GL_EXT_occlusion_query_boolean). ES 2.0 has no
+    // core query objects, so we forward to the driver's `*EXT` entry points.
+    // These are the exact functions iPhone OS games (e.g. Rush Rally 2) call
+    // through the `glGenQueriesEXT` family of symbols.
+    // Reference: https://registry.khronos.org/OpenGL/extensions/EXT/EXT_occlusion_query_boolean.txt
+    unsafe fn GenQueries(&mut self, n: GLsizei, ids: *mut GLuint) {
+        if gles2::GenQueriesEXT::is_loaded() {
+            gles2::GenQueriesEXT(n, ids)
+        } else {
+            log_once!(
+                "GenQueries: driver does not expose GL_EXT_occlusion_query_boolean [stubbed]"
+            );
+        }
+    }
+    unsafe fn DeleteQueries(&mut self, n: GLsizei, ids: *const GLuint) {
+        if gles2::DeleteQueriesEXT::is_loaded() {
+            gles2::DeleteQueriesEXT(n, ids)
+        }
+    }
+    unsafe fn IsQuery(&mut self, id: GLuint) -> GLboolean {
+        if gles2::IsQueryEXT::is_loaded() {
+            gles2::IsQueryEXT(id)
+        } else {
+            gles2::FALSE
+        }
+    }
+    unsafe fn BeginQuery(&mut self, target: GLenum, id: GLuint) {
+        if gles2::BeginQueryEXT::is_loaded() {
+            gles2::BeginQueryEXT(target, id)
+        }
+    }
+    unsafe fn EndQuery(&mut self, target: GLenum) {
+        if gles2::EndQueryEXT::is_loaded() {
+            gles2::EndQueryEXT(target)
+        }
+    }
+    unsafe fn GetQueryiv(&mut self, target: GLenum, pname: GLenum, params: *mut GLint) {
+        if gles2::GetQueryivEXT::is_loaded() {
+            gles2::GetQueryivEXT(target, pname, params)
+        }
+    }
+    unsafe fn GetQueryObjectuiv(&mut self, id: GLuint, pname: GLenum, params: *mut GLuint) {
+        if gles2::GetQueryObjectuivEXT::is_loaded() {
+            gles2::GetQueryObjectuivEXT(id, pname, params)
+        }
+    }
+
     // Uniforms
     unsafe fn Uniform1f(&mut self, location: GLint, v0: GLfloat) {
         gles2::Uniform1f(location, v0)


### PR DESCRIPTION
## Problem

Rush Rally 2 crashes on launch. From the attached `touchHLE_log`, the game boots fine — it creates the OpenGL ES 2.0 context, uploads its first textures, and issues its first `glClear` — then dies:

```
touchHLE::dyld: Warning: unhandled external relocation "_glGenQueriesEXT" in "Rush Rally 2" at 0x37491c
touchHLE::dyld: Warning: unhandled non-lazy symbol "_glGenQueriesEXT" at 0x37491c in "Rush Rally 2"
...
touchHLE::environment: Warning: Ignored UndefinedInstruction at 0x4000. Faking function return to LR (0x2677ed) to bypass crash!
```

The game links directly against the `glGenQueriesEXT` family from the **`GL_EXT_occlusion_query_boolean`** extension. Those symbols were never exported by the emulator, so the dynamic linker left the guest function pointer **null**. When the game called it, execution jumped to address `0x4000` (garbage) → `UndefinedInstruction`. The burst of NULL-PAGE reads right before the crash is the game reading back the query-ID array that `glGenQueriesEXT` should have filled.

## Fix

Implemented `GL_EXT_occlusion_query_boolean` end-to-end. Per the [Khronos registry](https://registry.khronos.org/OpenGL/extensions/EXT/EXT_occlusion_query_boolean.txt), the `*EXT` entry points are the OpenGL ES 2.0 form of the boolean occlusion query API and are semantically identical to the ES 3.0 core query objects (only the accepted `target`s differ), so each wrapper forwards to the existing core query path.

- **`gl_bindings/build.rs`** — generate the `*EXT` query bindings for the native ES 2.0 backend.
- **`gles_guest.rs`** — export `glGenQueriesEXT`, `glDeleteQueriesEXT`, `glIsQueryEXT`, `glBeginQueryEXT`, `glEndQueryEXT`, `glGetQueryivEXT`, `glGetQueryObjectuivEXT`, each forwarding to the existing core query wrapper. Also advertise the extension in the ES2 `GL_EXTENSIONS` string.
- **`gles2_native.rs`** — forward the core query trait methods to the driver's `*EXT` entry points, matching the existing VAO / `APPLE_framebuffer_multisample` pattern in the same file (guarded with `::is_loaded()`).

## Testing

- `cargo check --lib` passes with no new errors (only the crate's pre-existing warnings).
- Generated ES2 bindings confirmed to contain all seven `*EXT` symbols and the `GL_ANY_SAMPLES_PASSED*` tokens.

This is a real implementation — no stubs on the guest-facing path; calls are forwarded to the host driver's real occlusion-query functions when present.