### PR TITLE
foundation: format varargs in +[NSException raise:format:]

### DIFF
--- a/src/frameworks/foundation/ns_exception.rs
+++ b/src/frameworks/foundation/ns_exception.rs
@@ -18,6 +18,7 @@
 //! (which produces mysterious NULL-deref crashes later, as seen in the
 //! KamiChallenge log).
 
+use crate::abi::VaList;
 use crate::dyld::{ConstantExports, FunctionExports, HostConstant};
 use crate::mem::MutVoidPtr;
 use crate::objc::{
@@ -84,13 +85,45 @@ pub const CLASSES: ClassExports = objc_classes! {
 }
 
 // `+raise:format:` — convenience that creates and immediately raises.
-// The `format` parameter is treated as a plain reason string (no printf
-// substitution) because varargs are not supported in touchHLE HLE stubs.
-+ (())raise:(id)name   // NSString*  (exception name)
-       format:(id)fmt  // NSString*  (reason / format string)
+// Per Apple's documentation this is variadic:
+//   + (void)raise:(NSExceptionName)name format:(NSString *)format, ...;
+// The `format` argument is a printf-style format string and the reason is
+// produced by substituting the trailing varargs into it (the same machinery
+// `+[NSString stringWithFormat:]` uses). Previously the varargs were ignored
+// and `format` was used verbatim, so reasons like Parse SDK's
+// "...before calling %s!" were logged with the literal "%s" instead of the
+// selector name that was passed as an argument.
++ (())raise:(id)name          // NSString*  (exception name)
+       format:(id)fmt, ...args // NSString*  (printf-style reason format) + varargs
 {
+    let reason = if fmt == nil {
+        nil
+    } else {
+        let formatted = super::ns_string::with_format(env, fmt, args.start());
+        let ns = super::ns_string::from_rust_string(env, formatted);
+        autorelease(env, ns)
+    };
     let exc: id = msg_class![env; NSException exceptionWithName:name
-                                                         reason:fmt
+                                                         reason:reason
+                                                       userInfo:nil];
+    () = msg![env; exc raise];
+}
+
+// `+raise:format:arguments:` — the `va_list` sibling of the above, used by
+// code that forwards its own varargs (e.g. custom assertion wrappers).
++ (())raise:(id)name           // NSString*  (exception name)
+       format:(id)fmt          // NSString*  (printf-style reason format)
+    arguments:(VaList)args     // va_list of the format arguments
+{
+    let reason = if fmt == nil {
+        nil
+    } else {
+        let formatted = super::ns_string::with_format(env, fmt, args);
+        let ns = super::ns_string::from_rust_string(env, formatted);
+        autorelease(env, ns)
+    };
+    let exc: id = msg_class![env; NSException exceptionWithName:name
+                                                         reason:reason
                                                        userInfo:nil];
     () = msg![env; exc raise];
 }


### PR DESCRIPTION
## Problem

From the log:

```
GUEST NSException raised (Continuing without panic):
  Name:   NSInternalInconsistencyException
  Reason: You must set your configuration's `applicationId` before calling %s!
```

The reason contains a literal `%s`. The Parse SDK raised the exception with a printf-style format string plus an argument (the selector name), but touchHLE logged the format verbatim instead of substituting the argument.

## Root cause

`+[NSException raise:format:]` is **variadic** per [Apple's documentation](https://developer.apple.com/documentation/foundation/nsexception) (`+ (void)raise:(NSExceptionName)name format:(NSString *)format, ...;`). The implementation in `ns_exception.rs` declared it as a plain 2-argument method and used `format` directly as the reason, dropping the varargs entirely.

## Fix

- Make `+raise:format:` variadic (`, ...args`) and build the reason with the existing `ns_string::with_format` helper — the same printf engine `+[NSString stringWithFormat:]` already uses. Now `%s`, `%@`, `%d`, etc. are substituted correctly.
- Also implement the documented `+[NSException raise:format:arguments:]` (`va_list`) sibling, which Apple lists alongside it.
- `nil` format is handled (reason stays `nil`).

## Verification

- Syntax verified; the change lives inside the `objc_classes!` macro and follows the exact varargs pattern already used by `+[NSString stringWithFormat:]`, `+[NSArray arrayWithObjects:]`, etc.
- The two unrelated `rustfmt` nits in this file (a stray blank line and a `log_dbg!` wrap) pre-date this change and were left untouched to keep the diff minimal.