### PR TITLE
Fix EAGL and NSTimer Apple semantics

### DIFF
--- a/src/frameworks/core_animation/ca_eagl_layer.rs
+++ b/src/frameworks/core_animation/ca_eagl_layer.rs
@@ -15,13 +15,13 @@ use crate::Environment;
 //
 // These are the keys apps put in the drawableProperties dictionary.
 // We export them as static strings so other modules can reference them.
-pub const kEAGLDrawablePropertyRetainedBacking: &str = "kEAGLDrawablePropertyRetainedBacking";
-pub const kEAGLDrawablePropertyColorFormat: &str = "kEAGLDrawablePropertyColorFormat";
+pub const kEAGLDrawablePropertyRetainedBacking: &str = "RetainedBacking";
+pub const kEAGLDrawablePropertyColorFormat: &str = "ColorFormat";
 
 // kEAGLColorFormat values
-pub const kEAGLColorFormatRGBA8: &str = "kEAGLColorFormatRGBA8";
-pub const kEAGLColorFormatRGB565: &str = "kEAGLColorFormatRGB565";
-pub const kEAGLColorFormatSRGBA8: &str = "kEAGLColorFormatSRGBA8";
+pub const kEAGLColorFormatRGBA8: &str = "RGBA8";
+pub const kEAGLColorFormatRGB565: &str = "RGB565";
+pub const kEAGLColorFormatSRGBA8: &str = "SRGBA8";
 
 pub const CLASSES: ClassExports = objc_classes! {
 

--- a/src/frameworks/foundation/ns_timer.rs
+++ b/src/frameworks/foundation/ns_timer.rs
@@ -226,13 +226,19 @@ pub const CLASSES: ClassExports = objc_classes! {
 }
 
 - (())fire {
-    let &NSTimerHostObject {
-        target,
-        selector,
-        invocation,
-        repeats,
-        ..
-    } = env.objc.borrow(this);
+    let (target, selector, invocation, repeats, is_valid) = {
+        let host = env.objc.borrow::<NSTimerHostObject>(this);
+        (
+            host.target,
+            host.selector,
+            host.invocation,
+            host.repeats,
+            host.due_by.is_some(),
+        )
+    };
+    if !is_valid {
+        return;
+    }
     let pool: id = msg_class![env; NSAutoreleasePool new];
 
     if invocation != nil {

--- a/src/frameworks/opengles/eagl.rs
+++ b/src/frameworks/opengles/eagl.rs
@@ -255,7 +255,14 @@ pub const CLASSES: ClassExports = objc_classes! {
                fromDrawable:(id)drawable { // EAGLDrawable (always CAEAGLayer*)
     log!("[EAGLContext renderbufferStorage:{:#x} fromDrawable:{:?}]", target, drawable);
 
-    assert!(target == gles11::RENDERBUFFER_OES);
+    if target != gles11::RENDERBUFFER_OES {
+        log!(
+            "[EAGLContext renderbufferStorage:{:#x} fromDrawable:{:?}] invalid target; returning NO",
+            target,
+            drawable
+        );
+        return false;
+    }
 
     // Apple's `EAGLContext` documentation for
     // `-renderbufferStorage:fromDrawable:` states that passing `nil` for the
@@ -271,10 +278,13 @@ pub const CLASSES: ClassExports = objc_classes! {
     // (renderbuffer -> drawable) map, and release the retained drawable.
     // No new storage is allocated in this case.
     if drawable == nil {
-        let window = env
-            .window
-            .as_mut()
-            .expect("OpenGL ES is not supported in headless mode");
+        let Some(window) = env.window.as_mut() else {
+            log_dbg!(
+                "[EAGLContext renderbufferStorage:{:#x} fromDrawable:nil] ignored in headless mode",
+                target
+            );
+            return true;
+        };
         let current_renderbuffer = {
             let Some(mut gles) = super::sync_context(
                 &mut env.framework_state.opengles,
@@ -586,7 +596,13 @@ pub const CLASSES: ClassExports = objc_classes! {
         }
     }
 
-    assert!(target == gles11::RENDERBUFFER_OES);
+    if target != gles11::RENDERBUFFER_OES {
+        log!(
+            "[EAGLContext presentRenderbuffer:{:#x}] invalid target; returning NO",
+            target
+        );
+        return false;
+    }
 
     // The presented frame should be displayed ASAP, but the next one must be
     // delayed, so this needs to be checked before returning.
@@ -605,7 +621,13 @@ pub const CLASSES: ClassExports = objc_classes! {
 
     // Unclear from documentation if this method requires the context to be
     // current, but it would be weird if it didn't?
-    let window = env.window.as_mut().expect("OpenGL ES is not supported in headless mode");
+    let Some(window) = env.window.as_mut() else {
+        log_dbg!(
+            "[EAGLContext presentRenderbuffer:{:#x}] ignored in headless mode",
+            target
+        );
+        return false;
+    };
     let Some(mut gles) = super::sync_context(&mut env.framework_state.opengles, &mut env.objc, window, env.current_thread) else {
         // No current EAGL context. Apple's docs require the receiver to be
         // the current context for `presentRenderbuffer:` to succeed; the

--- a/src/log.rs
+++ b/src/log.rs
@@ -117,9 +117,7 @@ pub const ENABLED_MODULES: &[&str] = &[
     "touchHLE::window",
     "touchHLE::frameworks::uikit::ui_touch",
     "touchHLE::frameworks::uikit::ui_view",
-    "touchHLE::frameworks::opengles::eagl",
     "touchHLE::frameworks::uikit::ui_view_controller",
-    "touchHLE::frameworks::foundation::ns_timer",
     "touchHLE::frameworks::foundation::ns_run_loop",
     "touchHLE::frameworks::core_animation::ca_display_link",
 ];


### PR DESCRIPTION
## Summary
- use the documented EAGL drawable key/value strings so `drawableProperties` lookups work
- make `renderbufferStorage:` and `presentRenderbuffer:` return `NO` for invalid targets and remain safe in headless mode
- prevent an invalidated NSTimer from firing through a stale direct `-fire` call
- disable the two affected verbose debug modules to stop the log flood seen in `touchHLE_log.txt`

## Validation
- `git diff --check`
- balanced Rust delimiters in all changed Rust files
- source audit for the affected EAGL/NSTimer paths

Rust toolchain binaries are not installed in this environment, so `cargo fmt`/`cargo test` could not be run here.