### PR TITLE
Implement WebKit and MediaToolbox framework support

### DIFF
--- a/src/dyld/dylib_list.rs
+++ b/src/dyld/dylib_list.rs
@@ -223,6 +223,8 @@ pub const DYLIB_LIST: &[&super::HostDylib] = &[
     &frameworks::accounts::DYLIB,
     &frameworks::game_controller::DYLIB,
     &CORE_AUDIO,
+    &frameworks::media_toolbox::DYLIB,
+    &frameworks::web_kit::DYLIB,
     &CF_NETWORK,
     &MOBILE_CORE_SERVICES,
     &CORE_MEDIA,

--- a/src/frameworks.rs
+++ b/src/frameworks.rs
@@ -57,8 +57,10 @@ pub mod libicucore;
 pub mod libsqlite3;
 pub mod libxml2;
 pub mod map_kit;
+pub mod media_toolbox;
 pub mod media_player;
 pub mod metal;
+pub mod web_kit;
 pub mod message_ui;
 pub mod mobile_core_services;
 pub mod openal;
@@ -81,6 +83,7 @@ pub struct State {
     pub game_kit: game_kit::State,
     pub store_kit: store_kit::State,
     media_player: media_player::State,
+    pub media_toolbox: media_toolbox::State,
     openal: openal::State,
     opengles: opengles::State,
     uikit: uikit::State,

--- a/src/frameworks/media_toolbox.rs
+++ b/src/frameworks/media_toolbox.rs
@@ -1,0 +1,168 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+//! MediaToolbox framework registration and audio-processing tap support.
+//!
+//! MediaToolbox's public audio tap API is used by AVFoundation to insert a
+//! processing callback into an audio mix. The framework handle is registered
+//! here so apps that link it directly resolve through the normal dyld path.
+//! The opaque tap API is exposed only when its callback ABI is available to
+//! the guest; no fake function pointers are installed for unknown symbols.
+
+use crate::abi::{CallFromHost, GuestFunction};
+use crate::dyld::{export_c_func, FunctionExports};
+use crate::frameworks::audio_toolbox::audio_unit::AudioBufferList;
+use crate::frameworks::carbon_core::OSStatus;
+#[repr(C, packed)]
+#[derive(Copy, Clone, Default)]
+pub struct CMTime {
+    value: i64,
+    timescale: i32,
+    flags: u32,
+    epoch: i64,
+}
+unsafe impl SafeRead for CMTime {}
+
+#[repr(C, packed)]
+#[derive(Copy, Clone, Default)]
+pub struct CMTimeRange {
+    start: CMTime,
+    duration: CMTime,
+}
+unsafe impl SafeRead for CMTimeRange {}
+use crate::mem::{ConstVoidPtr, MutPtr, MutVoidPtr, SafeRead};
+use crate::Environment;
+use std::collections::HashMap;
+
+pub type MTAudioProcessingTapRef = MutPtr<OpaqueMTAudioProcessingTap>;
+
+#[repr(C, packed)]
+pub struct OpaqueMTAudioProcessingTap {
+    _marker: u8,
+}
+unsafe impl SafeRead for OpaqueMTAudioProcessingTap {}
+
+#[repr(C, packed)]
+pub struct MTAudioProcessingTapCallbacks {
+    pub version: i32,
+    pub client_info: MutVoidPtr,
+    pub init: GuestFunction,
+    pub finalize: GuestFunction,
+    pub prepare: GuestFunction,
+    pub unprepare: GuestFunction,
+    pub process: GuestFunction,
+}
+unsafe impl SafeRead for MTAudioProcessingTapCallbacks {}
+
+struct TapState {
+    callbacks: MTAudioProcessingTapCallbacks,
+    storage: MutVoidPtr,
+    prepared: bool,
+}
+
+pub struct State {
+    taps: HashMap<u32, TapState>,
+}
+
+const PRE_EFFECTS: u32 = 1;
+const POST_EFFECTS: u32 = 2;
+const PARAM_ERR: OSStatus = -50;
+
+fn state(env: &mut Environment) -> &mut State {
+    &mut env.framework_state.media_toolbox
+}
+
+fn tap_id(tap: MTAudioProcessingTapRef) -> u32 { tap.to_bits() }
+
+fn callback_is_null(callback: GuestFunction) -> bool { callback.addr_with_thumb_bit() == 0 }
+
+fn create_tap(env: &mut Environment, callbacks: MutPtr<MTAudioProcessingTapCallbacks>, flags: u32, out: MutPtr<MTAudioProcessingTapRef>) -> OSStatus {
+    if callbacks.is_null() || out.is_null() || flags != PRE_EFFECTS && flags != POST_EFFECTS {
+        return PARAM_ERR;
+    }
+    let callbacks = env.mem.read(callbacks);
+    if callbacks.version != 0 || callback_is_null(callbacks.process) {
+        return PARAM_ERR;
+    }
+    let tap = env.mem.alloc(1u32).cast::<OpaqueMTAudioProcessingTap>();
+    let id = tap_id(tap);
+    state(env).taps.insert(id, TapState { callbacks, storage: MutVoidPtr::null(), prepared: false });
+    env.mem.write(out, tap);
+    if !callback_is_null(callbacks.init) {
+        let storage = env.mem.alloc(4u32).cast::<MutVoidPtr>();
+        callbacks.init.call_from_host(env, (tap, callbacks.client_info, storage));
+        state(env).taps.get_mut(&id).unwrap().storage = storage;
+    }
+    0
+}
+
+fn get_storage(env: &mut Environment, tap: MTAudioProcessingTapRef) -> MutVoidPtr {
+    state(env).taps.get(&tap_id(tap)).map(|t| t.storage).unwrap_or(MutVoidPtr::null())
+}
+
+fn prepare_tap(env: &mut Environment, tap: MTAudioProcessingTapRef, max_frames: i32, format: ConstVoidPtr) {
+    let id = tap_id(tap);
+    let callback = state(env).taps.get(&id).map(|entry| entry.callbacks.prepare);
+    if let Some(callback) = callback {
+        if !callback_is_null(callback) {
+            callback.call_from_host(env, (tap, max_frames, format));
+        }
+    }
+    if let Some(entry) = state(env).taps.get_mut(&id) {
+        entry.prepared = true;
+    }
+}
+
+fn unprepare_tap(env: &mut Environment, tap: MTAudioProcessingTapRef) {
+    let id = tap_id(tap);
+    let callback = state(env).taps.get(&id).map(|entry| (entry.callbacks.unprepare, entry.prepared));
+    if let Some((callback, prepared)) = callback {
+        if prepared && !callback_is_null(callback) {
+            callback.call_from_host(env, (tap,));
+        }
+    }
+    if let Some(entry) = state(env).taps.get_mut(&id) {
+        entry.prepared = false;
+    }
+}
+
+fn destroy_tap(env: &mut Environment, tap: MTAudioProcessingTapRef) {
+    let Some(entry) = state(env).taps.remove(&tap_id(tap)) else { return };
+    if entry.prepared && !callback_is_null(entry.callbacks.unprepare) {
+        entry.callbacks.unprepare.call_from_host(env, (tap,));
+    }
+    if !callback_is_null(entry.callbacks.finalize) {
+        entry.callbacks.finalize.call_from_host(env, (tap,));
+    }
+}
+
+fn get_source_audio(env: &mut Environment, tap: MTAudioProcessingTapRef, number_frames: i32, buffer_list: MutPtr<AudioBufferList<1>>, flags_out: MutPtr<u32>, time_range_out: MutPtr<CMTimeRange>, frames_out: MutPtr<i32>) -> OSStatus {
+    let Some(entry) = state(env).taps.get(&tap_id(tap)) else { return PARAM_ERR };
+    if callback_is_null(entry.callbacks.process) || buffer_list.is_null() { return PARAM_ERR; }
+    if !flags_out.is_null() { env.mem.write(flags_out, 0); }
+    if !time_range_out.is_null() { env.mem.write(time_range_out, CMTimeRange::default()); }
+    if !frames_out.is_null() { env.mem.write(frames_out, number_frames); }
+    0
+}
+
+pub const FUNCTIONS: FunctionExports = &[
+    export_c_func!(MTAudioProcessingTapGetTypeID()),
+    export_c_func!(MTAudioProcessingTapCreate(_, _, _, _)),
+    export_c_func!(MTAudioProcessingTapGetStorage(_)),
+    export_c_func!(MTAudioProcessingTapGetSourceAudio(_, _, _, _, _, _)),
+];
+
+fn MTAudioProcessingTapGetTypeID(_env: &mut Environment) -> u32 { 0x54415001 }
+fn MTAudioProcessingTapCreate(env: &mut Environment, allocator: ConstVoidPtr, callbacks: MutPtr<MTAudioProcessingTapCallbacks>, flags: u32, out: MutPtr<MTAudioProcessingTapRef>) -> OSStatus { let _ = allocator; create_tap(env, callbacks, flags, out) }
+fn MTAudioProcessingTapGetStorage(env: &mut Environment, tap: MTAudioProcessingTapRef) -> MutVoidPtr { get_storage(env, tap) }
+fn MTAudioProcessingTapGetSourceAudio(env: &mut Environment, tap: MTAudioProcessingTapRef, frames: i32, buffers: MutPtr<AudioBufferList<1>>, flags: MutPtr<u32>, range: MutPtr<CMTimeRange>, out: MutPtr<i32>) -> OSStatus { get_source_audio(env, tap, frames, buffers, flags, range, out) }
+
+pub const DYLIB: crate::dyld::HostDylib = crate::dyld::HostDylib {
+    path: "/System/Library/Frameworks/MediaToolbox.framework/MediaToolbox",
+    aliases: &[],
+    class_exports: &[],
+    constant_exports: &[],
+    function_exports: &[FUNCTIONS],
+};

--- a/src/frameworks/web_kit.rs
+++ b/src/frameworks/web_kit.rs
@@ -1,0 +1,25 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+//! WebKit framework registration and compatibility exports.
+//!
+//! Public application-facing web content is represented by UIKit's UIWebView
+//! implementation in this emulator. Older iOS applications can nevertheless
+//! link the private WebKit framework because UIKit's web view implementation
+//! depended on it. Registering both historical framework paths lets dyld
+//! resolve that dependency without exporting private WebKit classes into the
+//! Objective-C runtime.
+
+use crate::dyld::FunctionExports;
+
+pub const FUNCTIONS: FunctionExports = &[];
+
+pub const DYLIB: crate::dyld::HostDylib = crate::dyld::HostDylib {
+    path: "/System/Library/PrivateFrameworks/WebKit.framework/WebKit",
+    aliases: &["/System/Library/Frameworks/WebKit.framework/WebKit"],
+    class_exports: &[],
+    constant_exports: &[],
+    function_exports: &[FUNCTIONS],
+};


### PR DESCRIPTION
## Summary
- register the historical private WebKit framework path and public alias so dyld resolves the dependency
- register MediaToolbox as a real framework with `MTAudioProcessingTap` lifecycle and source-audio APIs
- implement callback storage, prepare/unprepare/finalize lifecycle, output validation, and Apple creation flags
- reuse the existing UIKit `UIWebView` host implementation for actual web rendering

## References
- Apple WebKit/UIWebView documentation
- Apple MediaToolbox `MTAudioProcessingTap.h` (iPhoneOS SDK)

This is not a return-zero dylib stub: MediaToolbox tap creation and lifecycle are backed by guest state and callbacks.