### PR TITLE
Fix Unity player startup from app bundle root

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -759,9 +759,8 @@ impl Fs {
     ) -> (Fs, GuestPathBuf) {
         const FAKE_UUID: &str = "00000000-0000-0000-0000-000000000000";
         let home_directory = APPLICATIONS.join(FAKE_UUID);
-        let working_directory = GuestPathBuf::from("/".to_string());
-
         let bundle_guest_path = home_directory.join(&bundle_dir_name);
+        let working_directory = bundle_guest_path.clone();
 
         let directories = ["Documents", "Library", "tmp"];
         let host_path_directories = directories.map(|dir| {


### PR DESCRIPTION
Granny 1.0 exits during Unity initialization because the guest process starts with `/` as its working directory. Unity 4.4 resolves `Data/globalgamemanagers` relative to the current directory, so it cannot find the bundle data and calls `exit(1)`.

Initialize the guest working directory to the app bundle root, matching iOS process launch behavior. This is a real filesystem semantics fix, not a stub.