### PR TITLE
Log guest stack trace before exit

### DIFF
--- a/src/libc/stdlib.rs
+++ b/src/libc/stdlib.rs
@@ -808,9 +808,8 @@ fn exit(env: &mut Environment, exit_code: i32) {
         let _: () = func.call_from_host(env, ());
     }
 
-    // Log the exit so it's clear in CI/run logs why the process stopped;
-    // previously this exited silently, which made the logs end abruptly with no
-    // explanation.
+    log!("Guest exit({}) on emulated thread {}", exit_code, env.current_thread);
+    env.stack_trace_current();
     echo!("App called exit({}); touchHLE will now quit.", exit_code);
     std::process::exit(exit_code);
 }


### PR DESCRIPTION
The latest Granny log reaches `exit(1)` after the first worker thread is created, but the existing `exit()` handler only printed the exit code.

Record the emulated thread id and guest stack trace immediately before terminating. This exposes the actual Unity/Granny caller and avoids guessing at the cause in the next reproduction.