### PR TITLE
Trace Granny Unity resource path resolution

### DIFF
--- a/src/libc/posix_io.rs
+++ b/src/libc/posix_io.rs
@@ -358,8 +358,12 @@ pub fn open_direct(env: &mut Environment, path: ConstPtr<u8>, flags: i32) -> Fil
             let data_relative_path = relative_path.strip_prefix("Data/").unwrap_or(relative_path);
             let bundle_relative_path = format!("{bundle_root}/{relative_path}");
             let bundle_data_path = format!("{bundle_root}/Data/{data_relative_path}");
-            case_insensitive_path(env, &bundle_relative_path)
-                .or_else(|| case_insensitive_path(env, &bundle_data_path))
+            let result = case_insensitive_path(env, &bundle_relative_path)
+                .or_else(|| case_insensitive_path(env, &bundle_data_path));
+            if let Some(ref resolved) = result {
+                log_dbg!("Resolved app resource path {:?} to {:?}", path_string, resolved);
+            }
+            result
         })
         .unwrap_or_else(|| path_string.clone());
 

--- a/src/log.rs
+++ b/src/log.rs
@@ -120,4 +120,5 @@ pub const ENABLED_MODULES: &[&str] = &[
     "touchHLE::frameworks::uikit::ui_view_controller",
     "touchHLE::frameworks::foundation::ns_run_loop",
     "touchHLE::frameworks::core_animation::ca_display_link",
+    "touchHLE::libc::posix_io",
 ];


### PR DESCRIPTION
## Summary
- log how Unity resource paths resolve through the virtual filesystem
- preserve the existing bundle-root and `Data/` fallback behavior

## Validation
- `git diff --check`
- local build was unavailable because the Rust toolchain is not installed in the current sandbox
- CI build started for Linux/macOS

This diagnostic PR is intended to identify the remaining Granny 1.0 startup failure without adding a stub or changing engine behavior.