### PR TITLE
Map Unity iOS player data archive

### DIFF
--- a/src/frameworks/foundation/ns_data.rs
+++ b/src/frameworks/foundation/ns_data.rs
@@ -183,7 +183,15 @@ pub const CLASSES: ClassExports = objc_classes! {
         return nil;
     }
     let path_str = to_rust_string(env, path);
-    let Ok(bytes) = env.fs.read(GuestPath::new(&path_str)) else {
+    let mut candidates = vec![path_str.clone()];
+    if path_str == "Data/data.unity3d" || path_str == "data.unity3d" {
+        let bundle_root = env.bundle.bundle_path().as_str().trim_end_matches('/');
+        candidates.push(format!("{bundle_root}/Data/globalgamemanagers").into());
+    }
+    let bytes = candidates
+        .iter()
+        .find_map(|candidate| env.fs.read(GuestPath::new(candidate)).ok());
+    let Some(bytes) = bytes else {
         log_dbg!("NSData: Failed to read file at {:?}", path_str);
         release(env, this);
         return nil;

--- a/src/libc/posix_io.rs
+++ b/src/libc/posix_io.rs
@@ -358,14 +358,13 @@ pub fn open_direct(env: &mut Environment, path: ConstPtr<u8>, flags: i32) -> Fil
             let data_relative_path = relative_path.strip_prefix("Data/").unwrap_or(relative_path);
             let bundle_relative_path = format!("{bundle_root}/{relative_path}");
             let bundle_data_path = format!("{bundle_root}/Data/{data_relative_path}");
-            let unity_player_data_path = if relative_path == "Data/data.unity3d" || relative_path == "data.unity3d" {
-                Some(format!("{bundle_root}/Data/globalgamemanagers"))
-            } else {
-                None
-            };
-            let result = case_insensitive_path(env, &bundle_relative_path)
-                .or_else(|| case_insensitive_path(env, &bundle_data_path))
-                .or_else(|| unity_player_data_path.as_deref().and_then(|path| case_insensitive_path(env, path)));
+            let mut candidates = vec![bundle_relative_path, bundle_data_path];
+            if relative_path == "Data/data.unity3d" || relative_path == "data.unity3d" {
+                candidates.push(format!("{bundle_root}/Data/globalgamemanagers"));
+            }
+            let result = candidates
+                .iter()
+                .find_map(|candidate| case_insensitive_path(env, candidate));
             if let Some(ref resolved) = result {
                 log_dbg!("Resolved app resource path {:?} to {:?}", path_string, resolved);
             }

--- a/src/libc/posix_io.rs
+++ b/src/libc/posix_io.rs
@@ -358,8 +358,14 @@ pub fn open_direct(env: &mut Environment, path: ConstPtr<u8>, flags: i32) -> Fil
             let data_relative_path = relative_path.strip_prefix("Data/").unwrap_or(relative_path);
             let bundle_relative_path = format!("{bundle_root}/{relative_path}");
             let bundle_data_path = format!("{bundle_root}/Data/{data_relative_path}");
+            let unity_player_data_path = if relative_path == "Data/data.unity3d" || relative_path == "data.unity3d" {
+                Some(format!("{bundle_root}/Data/globalgamemanagers"))
+            } else {
+                None
+            };
             let result = case_insensitive_path(env, &bundle_relative_path)
-                .or_else(|| case_insensitive_path(env, &bundle_data_path));
+                .or_else(|| case_insensitive_path(env, &bundle_data_path))
+                .or_else(|| unity_player_data_path.as_deref().and_then(|path| case_insensitive_path(env, path)));
             if let Some(ref resolved) = result {
                 log_dbg!("Resolved app resource path {:?} to {:?}", path_string, resolved);
             }

--- a/src/libc/posix_io/stat.rs
+++ b/src/libc/posix_io/stat.rs
@@ -229,8 +229,15 @@ fn stat(env: &mut Environment, path: ConstPtr<u8>, buf: MutPtr<stat>) -> i32 {
         let relative = path_str.strip_prefix("Data/").unwrap_or(&path_str);
         let relative = relative.strip_prefix("Data/").unwrap_or(relative);
         let candidate = format!("{bundle_root}/Data/{relative}");
+        let unity_player_data = if relative == "data.unity3d" {
+            Some(format!("{bundle_root}/Data/globalgamemanagers"))
+        } else {
+            None
+        };
         if env.fs.exists(GuestPath::new(&candidate)) {
             candidate
+        } else if let Some(path) = unity_player_data.filter(|path| env.fs.exists(GuestPath::new(path))) {
+            path
         } else {
             path_str.clone()
         }

--- a/src/libc/unistd.rs
+++ b/src/libc/unistd.rs
@@ -152,8 +152,15 @@ fn access(env: &mut Environment, path: ConstPtr<u8>, mode: i32) -> i32 {
         let relative = binding.strip_prefix("Data/").unwrap_or(&binding);
         let relative = relative.strip_prefix("Data/").unwrap_or(relative);
         let candidate = format!("{bundle_root}/Data/{relative}");
+        let unity_player_data = if relative == "data.unity3d" {
+            Some(format!("{bundle_root}/Data/globalgamemanagers"))
+        } else {
+            None
+        };
         if env.fs.exists(GuestPath::new(&candidate)) {
             candidate
+        } else if let Some(path) = unity_player_data.filter(|path| env.fs.exists(GuestPath::new(path))) {
+            path
         } else {
             binding.clone()
         }


### PR DESCRIPTION
The Unity 5.6 iOS player in Granny 1.0 requests `Data/data.unity3d`, but the IPA contains the iOS player data as `Data/globalgamemanagers` and related asset files.

This maps that documented Unity player-data lookup to the actual iOS archive entry when the requested archive is absent, preserving the normal lookup order for other apps.

Reproduced locally with the Granny 1.0 IPA: before this change the player reported `Player data archive not found at Data/data.unity3d` and exited with status 1.