### PR TITLE
Remove incorrect Unity archive alias

### DIFF
--- a/src/frameworks/foundation/ns_data.rs
+++ b/src/frameworks/foundation/ns_data.rs
@@ -183,14 +183,7 @@ pub const CLASSES: ClassExports = objc_classes! {
         return nil;
     }
     let path_str = to_rust_string(env, path);
-    let mut candidates = vec![path_str.clone()];
-    if path_str == "Data/data.unity3d" || path_str == "data.unity3d" {
-        let bundle_root = env.bundle.bundle_path().as_str().trim_end_matches('/');
-        candidates.push(format!("{bundle_root}/Data/globalgamemanagers").into());
-    }
-    let bytes = candidates
-        .iter()
-        .find_map(|candidate| env.fs.read(GuestPath::new(candidate)).ok());
+    let bytes = env.fs.read(GuestPath::new(&path_str)).ok();
     let Some(bytes) = bytes else {
         log_dbg!("NSData: Failed to read file at {:?}", path_str);
         release(env, this);

--- a/src/libc/posix_io.rs
+++ b/src/libc/posix_io.rs
@@ -358,10 +358,7 @@ pub fn open_direct(env: &mut Environment, path: ConstPtr<u8>, flags: i32) -> Fil
             let data_relative_path = relative_path.strip_prefix("Data/").unwrap_or(relative_path);
             let bundle_relative_path = format!("{bundle_root}/{relative_path}");
             let bundle_data_path = format!("{bundle_root}/Data/{data_relative_path}");
-            let mut candidates = vec![bundle_relative_path, bundle_data_path];
-            if relative_path == "Data/data.unity3d" || relative_path == "data.unity3d" {
-                candidates.push(format!("{bundle_root}/Data/globalgamemanagers"));
-            }
+            let candidates = [bundle_relative_path, bundle_data_path];
             let result = candidates
                 .iter()
                 .find_map(|candidate| case_insensitive_path(env, candidate));

--- a/src/libc/posix_io/stat.rs
+++ b/src/libc/posix_io/stat.rs
@@ -229,15 +229,8 @@ fn stat(env: &mut Environment, path: ConstPtr<u8>, buf: MutPtr<stat>) -> i32 {
         let relative = path_str.strip_prefix("Data/").unwrap_or(&path_str);
         let relative = relative.strip_prefix("Data/").unwrap_or(relative);
         let candidate = format!("{bundle_root}/Data/{relative}");
-        let unity_player_data = if relative == "data.unity3d" {
-            Some(format!("{bundle_root}/Data/globalgamemanagers"))
-        } else {
-            None
-        };
         if env.fs.exists(GuestPath::new(&candidate)) {
             candidate
-        } else if let Some(path) = unity_player_data.filter(|path| env.fs.exists(GuestPath::new(path))) {
-            path
         } else {
             path_str.clone()
         }

--- a/src/libc/unistd.rs
+++ b/src/libc/unistd.rs
@@ -152,15 +152,8 @@ fn access(env: &mut Environment, path: ConstPtr<u8>, mode: i32) -> i32 {
         let relative = binding.strip_prefix("Data/").unwrap_or(&binding);
         let relative = relative.strip_prefix("Data/").unwrap_or(relative);
         let candidate = format!("{bundle_root}/Data/{relative}");
-        let unity_player_data = if relative == "data.unity3d" {
-            Some(format!("{bundle_root}/Data/globalgamemanagers"))
-        } else {
-            None
-        };
         if env.fs.exists(GuestPath::new(&candidate)) {
             candidate
-        } else if let Some(path) = unity_player_data.filter(|path| env.fs.exists(GuestPath::new(path))) {
-            path
         } else {
             binding.clone()
         }


### PR DESCRIPTION
Follow-up to #50.

Removes the incorrect `data.unity3d`/`Data/data.unity3d` aliases and the related libc path/stat/access fallbacks. The previous PR was merged before this cleanup commit, so this change is submitted separately.