### PR TITLE
Fix Asphalt 8 Android startup resolution

### DIFF
--- a/touchHLE_default_options.txt
+++ b/touchHLE_default_options.txt
@@ -342,3 +342,9 @@ com.wb.GreenLantern: --landscape-left --prefer-gles2-context
 
 # Where's My Water?: iPhone portrait OpenGL ES 1 profile.
 com.disney.SwampyGame: --device-family=iphone-3gs
+
+# Asphalt 8 Airborne 1.0.0
+# The old game targets a 480x320 iPhone 3GS surface. On Android, using the
+# physical phone resolution for the guest renderbuffer can exhaust memory
+# before the app creates its ES2 context; output scaling remains host-side.
+com.gameloft.asphalt8: --landscape-right --screen-size=480x320 --force-composition


### PR DESCRIPTION
The Android log reaches the Asphalt 8 worker thread and fails before the app creates its ES2 context.

This adds a default profile for com.gameloft.asphalt8 that keeps the guest surface at the original 480x320 iPhone 3GS size while preserving landscape orientation and compositor presentation. Host-side output scaling still fills the Android display.

Validated with the available Linux build and 65/67 library tests; the two failures are pre-existing duplicate-export tests on current trunk.