### PR TITLE
Add GLES1 to GLES2 translator toggle

### DIFF
--- a/src/environment/app_picker.rs
+++ b/src/environment/app_picker.rs
@@ -149,6 +149,7 @@ struct AppPickerDelegateHostObject {
     orientation_portrait_upside_down: bool,
     analog_stick_tilt_controls: Option<bool>,
     network: Option<bool>,
+    gles1_on_gles2: Option<bool>,
     fullscreen: Option<bool>,
     device_model_tag: Option<i32>,
     device_model_toggle: bool,
@@ -233,6 +234,10 @@ const CLASSES: ClassExports = objc_classes! {
 - (())analogStickTiltControls:(id)switch { // UISwitch*
     let switch_state: bool = msg![env; switch isOn];
     env.objc.borrow_mut::<AppPickerDelegateHostObject>(this).analog_stick_tilt_controls = Some(switch_state);
+}
+- (())gles1OnGLES2:(id)switch { // UISwitch*
+    let switch_state: bool = msg![env; switch isOn];
+    env.objc.borrow_mut::<AppPickerDelegateHostObject>(this).gles1_on_gles2 = Some(switch_state);
 }
 - (())network:(id)switch { // UISwitch*
     let switch_state: bool = msg![env; switch isOn];
@@ -550,6 +555,7 @@ fn app_picker_inner(
     let mut quick_options_orientation: Option<DeviceOrientation> = None;
     let mut quick_options_analog_stick_tilt_controls = true;
     let mut quick_options_network = false;
+    let mut quick_options_gles1_on_gles2 = false;
     let mut quick_options_device_tag: Option<i32> = None;
     let mut quick_options_device_model_open = false;
     let mut quick_options_device_model_scroll: isize = 0;
@@ -796,6 +802,8 @@ fn app_picker_inner(
             quick_options_analog_stick_tilt_controls = enabled;
         } else if let Some(enabled) = std::mem::take(&mut host_obj.network) {
             quick_options_network = enabled;
+        } else if let Some(enabled) = std::mem::take(&mut host_obj.gles1_on_gles2) {
+            quick_options_gles1_on_gles2 = enabled;
         } else if let Some(fullscreen) = std::mem::take(&mut host_obj.fullscreen) {
             quick_options_fullscreen = match fullscreen {
                 false => None,
@@ -824,6 +832,9 @@ fn app_picker_inner(
     }
     if !quick_options_analog_stick_tilt_controls {
         option_args.push("--disable-analog-stick-tilt-controls".to_string());
+    }
+    if quick_options_gles1_on_gles2 {
+        option_args.push("--gles1=gles1_on_gles2".to_string());
     }
     if quick_options_network {
         option_args.push("--allow-network-access".to_string());
@@ -1516,6 +1527,8 @@ fn setup_quick_options(
         RowKind::Switch("network:", false),
         RowKind::Label("Use analog sticks for tilt controls"),
         RowKind::Switch("analogStickTiltControls:", true),
+        RowKind::Label("Use GLES1 → GLES2 translator"),
+        RowKind::Switch("gles1OnGLES2:", false),
         // ---- (divider for stuff skipped below)
         RowKind::Label("Fullscreen (override)"),
         RowKind::Switch("fullscreen:", false),


### PR DESCRIPTION
## Summary
- add a Quick options switch for the GLES1 → GLES2 translator
- pass `--gles1=gles1_on_gles2` when enabled for the selected app
- keep the switch disabled by default

## Validation
- `git diff --check` passes
- branch is based directly on current `trunk`

This is intentionally a separate PR because the previous PR was merged before this UI change was included.