### PR TITLE
Implement GLES1 framebuffer attachment query

### DIFF
--- a/src/gles/gles1_on_gles2.rs
+++ b/src/gles/gles1_on_gles2.rs
@@ -472,6 +472,7 @@ impl GLES for GLES1OnGLES2<'_> {
     unsafe fn RenderbufferStorageOES(&mut self, t: GLenum, f: GLenum, w: GLsizei, h: GLsizei) { gl::RenderbufferStorage(t, f, w, h); }
     unsafe fn FramebufferRenderbufferOES(&mut self, t: GLenum, a: GLenum, rt: GLenum, r: GLuint) { gl::FramebufferRenderbuffer(t, a, rt, r); }
     unsafe fn FramebufferTexture2DOES(&mut self, t: GLenum, a: GLenum, tt: GLenum, tex: GLuint, level: GLint) { gl::FramebufferTexture2D(t, a, tt, tex, level); }
+    unsafe fn GetFramebufferAttachmentParameterivOES(&mut self, t: GLenum, a: GLenum, p: GLenum, params: *mut GLint) { gl::GetFramebufferAttachmentParameteriv(t, a, p, params); }
     unsafe fn GenerateMipmapOES(&mut self, t: GLenum) { gl::GenerateMipmap(t); }
     unsafe fn CheckFramebufferStatus(&mut self, t: GLenum) -> GLenum { gl::CheckFramebufferStatus(t) }
     unsafe fn BindFramebuffer(&mut self, t: GLenum, f: GLuint) { gl::BindFramebuffer(t, f); }


### PR DESCRIPTION
## Summary
- implement `GetFramebufferAttachmentParameterivOES` in the GLES1 → GLES2 translator
- forward the OES query to the equivalent GLES2 framebuffer query

## Problem
LEGO Ninjago calls `GetFramebufferAttachmentParameterivOES` while running through the translator. The generic fallback panicked with:

`not implemented: GetFramebufferAttachmentParameterivOES not implemented by this backend`

## Validation
- `git diff --check` passes
- implementation is limited to the missing backend method reported by the supplied crash log