### PR TITLE
Implement GLES1 GetIntegerv in GLES2 translator

### DIFF
--- a/src/gles/gles1_on_gles2.rs
+++ b/src/gles/gles1_on_gles2.rs
@@ -451,6 +451,7 @@ impl GLES for GLES1OnGLES2<'_> {
     unsafe fn ClearColorx(&mut self, r: GLclampx, g: GLclampx, b: GLclampx, a: GLclampx) { self.ClearColor(fixed_to_float(r), fixed_to_float(g), fixed_to_float(b), fixed_to_float(a)); }
     unsafe fn ClearDepthf(&mut self, d: GLclampf) { gl::ClearDepthf(d); }
     unsafe fn ClearStencil(&mut self, s: GLint) { gl::ClearStencil(s); }
+    unsafe fn GetIntegerv(&mut self, pname: GLenum, params: *mut GLint) { gl::GetIntegerv(pname, params); }
     unsafe fn DepthFunc(&mut self, f: GLenum) { gl::DepthFunc(f); }
     unsafe fn DepthMask(&mut self, f: GLboolean) { gl::DepthMask(f); }
     unsafe fn CullFace(&mut self, f: GLenum) { gl::CullFace(f); }


### PR DESCRIPTION
## Summary
- implement `glGetIntegerv` for the GLES1-on-GLES2 backend
- forward the query to the native GLES2 driver

## Motivation
The Ninjago: Rise of the Snakes app crashes immediately after creating its GLES1 context because the translator falls back to the generic `GetIntegerv` panic:

```text
not implemented: GetIntegerv not implemented by this backend
```

## Validation
- `git diff --check` passes
- based on current `trunk`
- CI will verify Android and desktop builds