### PR TITLE
perf: avoid GLES frame-path churn and PVRTC/audio stalls

### DIFF
--- a/src/frameworks/audio_toolbox/audio_unit.rs
+++ b/src/frameworks/audio_toolbox/audio_unit.rs
@@ -1241,8 +1241,14 @@ pub fn render_audio_unit(env: &mut Environment, audio_unit: AudioUnit) {
         }
     }
 
+    // PERF OPTIMIZATION (audio): keep a few buffers queued ahead of playback
+    // instead of throttling at ~1. The old cap meant any main-thread hitch
+    // longer than a single buffer (~12-23ms) drained the OpenAL queue dry and
+    // produced an audible dropout/crackle. Allowing ~4 buffers of slack
+    // (~50ms) rides out hitches at the cost of imperceptible extra latency;
+    // the throttle below still reclaims buffers and re-syncs if we run ahead.
     let remaining_buffers = queued_buffers.saturating_sub(processed_buffers);
-    if remaining_buffers > 1 {
+    if remaining_buffers > 3 {
         let mut drained_buffers = Vec::new();
         {
             let context = env

--- a/src/frameworks/opengles/eagl.rs
+++ b/src/frameworks/opengles/eagl.rs
@@ -1172,16 +1172,16 @@ unsafe fn present_renderbuffer_es2(
         (w, h)
     };
 
-    let mut pixels = vec![
-        0u8;
-        (width.max(0) as usize)
-            .saturating_mul(height.max(0) as usize)
-            .saturating_mul(4)
-    ];
+    // PERF OPTIMIZATION: the frame is resolved on the GPU below via
+    // glCopyTexImage2D (fast path). A CPU-side pixel buffer is only allocated
+    // in the unlikely fallback branch, not unconditionally on every frame.
+    let mut pixels: Vec<u8> = Vec::new();
+    let needs_cpu_fallback = width <= 0 || height <= 0;
+    let present_objects = ensure_present_objects(gles);
     if options.trace_gl_errors {
         log!("PRESENTATION: viewport={:?}, rotation={:?}", viewport, rotation_matrix);
     }
-    if width > 0 && height > 0 && !pixels.is_empty() {
+    if !needs_cpu_fallback {
         // Diagnostic: check if the buffer is actually empty (all zeros/black)
         static LOGGED_EMPTY: std::sync::Once = std::sync::Once::new();
         LOGGED_EMPTY.call_once(|| {
@@ -1214,25 +1214,35 @@ unsafe fn present_renderbuffer_es2(
             gles2::RENDERBUFFER,
             renderbuffer as GLuint,
         );
-        gles.Finish();
-        gles.ReadPixels(
+        // PERF OPTIMIZATION: copy the renderbuffer into the present texture
+        // directly on the GPU. The old path did glFinish() (full pipeline
+        // stall) + glReadPixels() (GPU->CPU copy of the whole frame), then
+        // re-uploaded the same pixels with glTexImage2D (CPU->GPU) — a costly
+        // round-trip on every single presented frame.
+        // NOTE: the copy target MUST be the real present texture object
+        // (binding 0 is not a texture object in ES2 -> GL_INVALID_OPERATION).
+        // There is no feedback loop here: the copy source FBO has only the
+        // renderbuffer attached, not this texture.
+        gles.ActiveTexture(gles2::TEXTURE0);
+        gles.BindTexture(gles2::TEXTURE_2D, present_objects.texture);
+        gles.CopyTexImage2D(
+            gles2::TEXTURE_2D,
+            0,
+            gles2::RGBA,
             0,
             0,
             width,
             height,
-            gles2::RGBA,
-            gles2::UNSIGNED_BYTE,
-            pixels.as_mut_ptr().cast(),
+            0,
         );
         gles.BindFramebuffer(gles2::FRAMEBUFFER, old_rb as _);
         gles.DeleteFramebuffers(1, &src_framebuffer);
         static LOGGED: std::sync::Once = std::sync::Once::new();
         LOGGED.call_once(|| {
-            log!("GLES2 presenter: using RGBA CPU readback before texture presentation")
+            log!("GLES2 presenter: resolving frame on GPU (glCopyTexImage2D fast path)")
         });
     }
 
-    let present_objects = ensure_present_objects(gles);
     gles.BindFramebuffer(gles2::FRAMEBUFFER, present_objects.framebuffer);
     if options.trace_gl_errors {
         log!("PRESENTATION: binding framebuffer {}", present_objects.framebuffer);

--- a/src/frameworks/opengles/eagl.rs
+++ b/src/frameworks/opengles/eagl.rs
@@ -1151,19 +1151,8 @@ unsafe fn present_renderbuffer_es2(
     let blend_was_on = gles.IsEnabled(gles2::BLEND) != 0;
     let scissor_was_on = gles.IsEnabled(gles2::SCISSOR_TEST) != 0;
 
-    // Save the enabled state of every vertex attribute slot we might touch.
-    // The app may have left attributes 0..N enabled; mutating them here would
-    // break its next draw call.
-    let mut attrib_was_enabled = [0u8; 16];
-    for (i, slot) in attrib_was_enabled.iter_mut().enumerate() {
-        let mut v: GLint = 0;
-        gles.GetVertexAttribiv(i as GLuint, gles2::VERTEX_ATTRIB_ARRAY_ENABLED, &mut v);
-        *slot = v as u8;
-    }
-
-    // Resolve renderbuffer → texture with a cached FBO + `glCopyTexImage2D`,
-    // using the ES 2.0 entry points.
-    let renderbuffer_int = renderbuffer as GLint;
+    // Resolve renderbuffer → texture with cached GL objects and the ES 2.0
+    // entry points.
     let (width, height) = {
         let mut w: GLint = 0;
         let mut h: GLint = 0;
@@ -1172,120 +1161,61 @@ unsafe fn present_renderbuffer_es2(
         (w, h)
     };
 
-    // PERF OPTIMIZATION: the frame is resolved on the GPU below via
-    // glCopyTexImage2D (fast path). A CPU-side pixel buffer is only allocated
-    // in the unlikely fallback branch, not unconditionally on every frame.
-    let mut pixels: Vec<u8> = Vec::new();
-    let needs_cpu_fallback = width <= 0 || height <= 0;
     let present_objects = ensure_present_objects(gles);
-    if options.trace_gl_errors {
-        log!("PRESENTATION: viewport={:?}, rotation={:?}", viewport, rotation_matrix);
-    }
-    if !needs_cpu_fallback {
-        // Diagnostic: check if the buffer is actually empty (all zeros/black)
-        static LOGGED_EMPTY: std::sync::Once = std::sync::Once::new();
-        LOGGED_EMPTY.call_once(|| {
-            let is_empty = pixels.iter().all(|&p| p == 0);
-            log!(
-                "GLES2 presenter diagnostic: buffer size {}x{}, is_all_zeros={}",
-                width,
-                height,
-                is_empty
+    if width > 0 && height > 0 {
+        // Reuse one FBO as the copy source. Reattach only when the app
+        // creates a new EAGL renderbuffer.
+        let source_renderbuffer = PRESENT_SOURCE_RENDERBUFFER.with(|cell| cell.get());
+        gles.BindFramebuffer(gles2::FRAMEBUFFER, present_objects.framebuffer);
+        if source_renderbuffer != renderbuffer {
+            gles.FramebufferRenderbuffer(
+                gles2::FRAMEBUFFER,
+                gles2::COLOR_ATTACHMENT0,
+                gles2::RENDERBUFFER,
+                renderbuffer,
             );
-        });
+            PRESENT_SOURCE_RENDERBUFFER.with(|cell| cell.set(renderbuffer));
+        }
 
-        // Read from the *renderbuffer being presented*, not from whatever
-        // framebuffer the guest happened to leave bound. On iOS the EAGL
-        // renderbuffer IS the default framebuffer, so apps can leave any
-        // binding here — including an offscreen/MSAA FBO whose content is
-        // not what's being presented. Reading from the stale binding yields
-        // black frames (Asphalt 8's Jet engine leaves its own FBO bound).
-        // Attach the renderbuffer to a dedicated FBO and read from that,
-        // mirroring `read_renderbuffer()`'s hardcoded safe path.
-        let mut old_rb: GLint = 0;
-        gles
-            .GetIntegerv(gles2::FRAMEBUFFER_BINDING, &mut old_rb);
-        let mut src_framebuffer: GLuint = 0;
-        gles.GenFramebuffers(1, &mut src_framebuffer);
-        gles.BindFramebuffer(gles2::FRAMEBUFFER, src_framebuffer);
-        gles.FramebufferRenderbuffer(
-            gles2::FRAMEBUFFER,
-            gles2::COLOR_ATTACHMENT0,
-            gles2::RENDERBUFFER,
-            renderbuffer as GLuint,
-        );
-        // PERF OPTIMIZATION: copy the renderbuffer into the present texture
-        // directly on the GPU. The old path did glFinish() (full pipeline
-        // stall) + glReadPixels() (GPU->CPU copy of the whole frame), then
-        // re-uploaded the same pixels with glTexImage2D (CPU->GPU) — a costly
-        // round-trip on every single presented frame.
-        // NOTE: the copy target MUST be the real present texture object
-        // (binding 0 is not a texture object in ES2 -> GL_INVALID_OPERATION).
-        // There is no feedback loop here: the copy source FBO has only the
-        // renderbuffer attached, not this texture.
+        // Copy into preallocated texture storage. CopyTexImage2D reallocates
+        // that storage on every frame, while CopyTexSubImage2D does not.
         gles.ActiveTexture(gles2::TEXTURE0);
         gles.BindTexture(gles2::TEXTURE_2D, present_objects.texture);
-        gles.CopyTexImage2D(
+        let texture_size = PRESENT_TEXTURE_SIZE.with(|cell| cell.get());
+        if texture_size != Some((width, height)) {
+            gles.TexImage2D(
+                gles2::TEXTURE_2D,
+                0,
+                gles2::RGBA as GLint,
+                width,
+                height,
+                0,
+                gles2::RGBA,
+                gles2::UNSIGNED_BYTE,
+                std::ptr::null(),
+            );
+            PRESENT_TEXTURE_SIZE.with(|cell| cell.set(Some((width, height))));
+        }
+        gles.CopyTexSubImage2D(
             gles2::TEXTURE_2D,
             0,
-            gles2::RGBA,
+            0,
+            0,
             0,
             0,
             width,
             height,
-            0,
         );
-        gles.BindFramebuffer(gles2::FRAMEBUFFER, old_rb as _);
-        gles.DeleteFramebuffers(1, &src_framebuffer);
+        gles.BindFramebuffer(gles2::FRAMEBUFFER, old_framebuffer as _);
         static LOGGED: std::sync::Once = std::sync::Once::new();
         LOGGED.call_once(|| {
-            log!("GLES2 presenter: resolving frame on GPU (glCopyTexImage2D fast path)")
+            log!("GLES2 presenter: cached FBO and glCopyTexSubImage2D fast path")
         });
     }
-
-    gles.BindFramebuffer(gles2::FRAMEBUFFER, present_objects.framebuffer);
-    if options.trace_gl_errors {
-        log!("PRESENTATION: binding framebuffer {}", present_objects.framebuffer);
-    }
-    gles.FramebufferRenderbuffer(
-        gles2::FRAMEBUFFER,
-        gles2::COLOR_ATTACHMENT0,
-        gles2::RENDERBUFFER,
-        renderbuffer as GLuint,
-    );
 
     gles.ActiveTexture(gles2::TEXTURE0);
     gles.BindTexture(gles2::TEXTURE_2D, present_objects.texture);
-    if !pixels.is_empty() {
-        gles.TexImage2D(
-            gles2::TEXTURE_2D,
-            0,
-            gles2::RGBA as GLint,
-            width,
-            height,
-            0,
-            gles2::RGBA,
-            gles2::UNSIGNED_BYTE,
-            pixels.as_ptr().cast(),
-        );
-    }
     gles.BindBuffer(gles2::ARRAY_BUFFER, present_objects.quad_vbo);
-    #[rustfmt::skip]
-    let verts: [f32; 24] = [
-        // x, y, u, v
-        -1.0, -1.0, 0.0, 0.0,
-         1.0, -1.0, 1.0, 0.0,
-        -1.0,  1.0, 0.0, 1.0,
-         1.0, -1.0, 1.0, 0.0,
-         1.0,  1.0, 1.0, 1.0,
-        -1.0,  1.0, 0.0, 1.0,
-    ];
-    gles.BufferData(
-        gles2::ARRAY_BUFFER,
-        std::mem::size_of_val(&verts) as isize,
-        verts.as_ptr().cast(),
-        gles2::STREAM_DRAW,
-    );
     gles.BindFramebuffer(gles2::FRAMEBUFFER, 0);
 
     // Configure the destination viewport (the window) and clear.
@@ -1308,14 +1238,6 @@ unsafe fn present_renderbuffer_es2(
     // remains on screen and the app continues to run.
     let Some(program) = ensure_present_program(gles) else {
         log!("Warning: present_renderbuffer_es2: present shader unavailable, skipping frame.");
-        // Restore vertex attribute enabled state so the app's next draw works.
-        for (i, &was) in attrib_was_enabled.iter().enumerate() {
-            if was != 0 {
-                gles.EnableVertexAttribArray(i as GLuint);
-            } else {
-                gles.DisableVertexAttribArray(i as GLuint);
-            }
-        }
         gles.UseProgram(if old_program > 0 {
             old_program as GLuint
         } else {
@@ -1354,6 +1276,17 @@ unsafe fn present_renderbuffer_es2(
         }
         return;
     };
+
+    // The presenter only changes the two attributes it owns. Querying all 16
+    // slots on every frame is unnecessary driver traffic.
+    let attribute_slots = [program.a_pos as GLuint, program.a_uv as GLuint];
+    let mut attrib_was_enabled = [0u8; 2];
+    for (slot, &attribute) in attrib_was_enabled.iter_mut().zip(attribute_slots.iter()) {
+        let mut v: GLint = 0;
+        gles.GetVertexAttribiv(attribute, gles2::VERTEX_ATTRIB_ARRAY_ENABLED, &mut v);
+        *slot = v as u8;
+    }
+
     gles.UseProgram(program.program);
     gles.Uniform1i(program.u_tex, 0);
     let m = crate::matrix::Matrix::<4>::from(&rotation_matrix);
@@ -1413,11 +1346,11 @@ unsafe fn present_renderbuffer_es2(
     }
 
     // Restore vertex attribute enabled state so the app's next draw works.
-    for (i, &was) in attrib_was_enabled.iter().enumerate() {
+    for (&attribute, &was) in attribute_slots.iter().zip(attrib_was_enabled.iter()) {
         if was != 0 {
-            gles.EnableVertexAttribArray(i as GLuint);
+            gles.EnableVertexAttribArray(attribute);
         } else {
-            gles.DisableVertexAttribArray(i as GLuint);
+            gles.DisableVertexAttribArray(attribute);
         }
     }
 
@@ -1504,6 +1437,10 @@ thread_local! {
     static PRESENT_PROGRAM: std::cell::Cell<Option<PresentProgram>> =
         const { std::cell::Cell::new(None) };
     static PRESENT_OBJECTS: std::cell::Cell<Option<PresentObjects>> =
+        const { std::cell::Cell::new(None) };
+    static PRESENT_SOURCE_RENDERBUFFER: std::cell::Cell<GLuint> =
+        const { std::cell::Cell::new(0) };
+    static PRESENT_TEXTURE_SIZE: std::cell::Cell<Option<(GLint, GLint)>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -1636,6 +1573,22 @@ unsafe fn ensure_present_objects(gles: &mut dyn GLES) -> PresentObjects {
     gles.GenTextures(1, &mut texture);
     let mut quad_vbo: GLuint = 0;
     gles.GenBuffers(1, &mut quad_vbo);
+    gles.BindBuffer(crate::gles::gles2_raw::ARRAY_BUFFER, quad_vbo);
+    #[rustfmt::skip]
+    let verts: [f32; 24] = [
+        -1.0, -1.0, 0.0, 0.0,
+         1.0, -1.0, 1.0, 0.0,
+        -1.0,  1.0, 0.0, 1.0,
+         1.0, -1.0, 1.0, 0.0,
+         1.0,  1.0, 1.0, 1.0,
+        -1.0,  1.0, 0.0, 1.0,
+    ];
+    gles.BufferData(
+        crate::gles::gles2_raw::ARRAY_BUFFER,
+        std::mem::size_of_val(&verts) as isize,
+        verts.as_ptr().cast(),
+        crate::gles::gles2_raw::STATIC_DRAW,
+    );
     gles.ActiveTexture(crate::gles::gles2_raw::TEXTURE0);
     gles.BindTexture(crate::gles::gles2_raw::TEXTURE_2D, texture);
     gles.TexParameteri(
@@ -1664,6 +1617,8 @@ unsafe fn ensure_present_objects(gles: &mut dyn GLES) -> PresentObjects {
         texture,
         quad_vbo,
     };
+    PRESENT_SOURCE_RENDERBUFFER.with(|cell| cell.set(0));
+    PRESENT_TEXTURE_SIZE.with(|cell| cell.set(None));
     PRESENT_OBJECTS.with(|c| c.set(Some(result)));
     result
 }

--- a/src/frameworks/system_configuration/sc_network_reachability.rs
+++ b/src/frameworks/system_configuration/sc_network_reachability.rs
@@ -142,7 +142,7 @@ fn SCNetworkReachabilitySetCallback(
         .borrow_mut::<SCNetworkReachabilityHostObject>(target);
     host.callout = Some(callout);
     host.context = context;
-    false
+    true
 }
 
 fn SCNetworkReachabilityScheduleWithRunLoop(

--- a/src/frameworks/system_configuration/sc_network_reachability.rs
+++ b/src/frameworks/system_configuration/sc_network_reachability.rs
@@ -156,7 +156,7 @@ fn SCNetworkReachabilityScheduleWithRunLoop(
         (host.callout, host.context)
     };
     if let Some(callback) = callback {
-        env.sleep(std::time::Duration::from_millis(16));
+        env.sleep(std::time::Duration::ZERO);
         let flags = kSCNetworkReachabilityFlagsReachable
             | kSCNetworkReachabilityFlagsIsDirect
             | kSCNetworkReachabilityFlagsIsWWAN;

--- a/src/gles/util.rs
+++ b/src/gles/util.rs
@@ -9,6 +9,42 @@ use super::gles11_raw as gles11; // constants only
 use super::gles11_raw::types::{GLenum, GLfixed, GLfloat, GLint, GLsizei};
 use super::GLES;
 
+/// PERF OPTIMIZATION (loading): cache of recently decoded PVRTC textures.
+/// Unity apps commonly destroy and re-create the same compressed textures
+/// across scene transitions; decoding PVRTC is one of the biggest chunks of
+/// load time. Entries are keyed by (content hash, params), so a re-upload of
+/// identical payload skips the expensive software decode entirely.
+///
+/// The cache is bounded by a total-decoded-bytes budget to keep host memory
+/// usage predictable (decoded RGBA8 is 4-8x the compressed size).
+const PVRTC_CACHE_MAX_ENTRIES: usize = 12;
+const PVRTC_CACHE_MAX_BYTES: usize = 48 * 1024 * 1024;
+
+struct PvrtcCacheEntry {
+    key: u64,
+    is_2bit: bool,
+    is_opaque: bool,
+    width: u32,
+    height: u32,
+    /// Decoded RGBA8 (one `u32` per texel, as returned by `decode_pvrtc`).
+    pixels: std::rc::Rc<[u32]>,
+}
+
+use std::cell::RefCell;
+thread_local! {
+    static PVRTC_DECODE_CACHE: RefCell<Vec<PvrtcCacheEntry>> = const { RefCell::new(Vec::new()) };
+}
+
+/// FNV-1a 64-bit hash of the compressed payload.
+fn fnv1a_hash(data: &[u8]) -> u64 {
+    let mut hash: u64 = 0xcbf29ce484222325;
+    for &byte in data {
+        hash ^= byte as u64;
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash
+}
+
 /// Convert a fixed-point scalar to a floating-point scalar.
 ///
 /// Beware: Rust's type checker won't complain if you mix up [GLfixed] with
@@ -260,8 +296,57 @@ pub fn try_decode_pvrtc(
         gles11::COMPRESSED_RGB_PVRTC_4BPPV1_IMG | gles11::COMPRESSED_RGB_PVRTC_2BPPV1_IMG
     );
     let upload_format = gles11::RGBA;
-    let pixels =
-        crate::image::decode_pvrtc_with_alpha(pvrtc_data, is_2bit, width_u, height_u, is_opaque);
+
+    // Look up the decoded result in the cache before doing the (expensive)
+    // software decode.
+    let key = fnv1a_hash(pvrtc_data);
+    let cached = PVRTC_DECODE_CACHE.with(|cache| {
+        let mut cache = cache.borrow_mut();
+        if let Some(pos) = cache.iter().position(|e| {
+            e.key == key
+                && e.is_2bit == is_2bit
+                && e.is_opaque == is_opaque
+                && e.width == width_u
+                && e.height == height_u
+        }) {
+            // Move-to-front for simple LRU behaviour.
+            let entry = cache.remove(pos);
+            cache.insert(0, entry);
+            let entry = &cache[0];
+            Some(entry.pixels.clone())
+        } else {
+            None
+        }
+    });
+
+    let pixels: std::rc::Rc<[u32]> = cached.unwrap_or_else(|| {
+        let decoded: Vec<u32> =
+            crate::image::decode_pvrtc_with_alpha(pvrtc_data, is_2bit, width_u, height_u, is_opaque);
+        let decoded: std::rc::Rc<[u32]> = decoded.into();
+        PVRTC_DECODE_CACHE.with(|cache| {
+            let mut cache = cache.borrow_mut();
+            // Evict least-recently-used entries until the new entry fits
+            // within the entry-count and byte-budget limits.
+            let decoded_bytes = decoded.len() * std::mem::size_of::<u32>();
+            let mut total_bytes: usize = cache.iter().map(|e| e.pixels.len() * std::mem::size_of::<u32>()).sum();
+            while cache.len() >= PVRTC_CACHE_MAX_ENTRIES
+                || total_bytes + decoded_bytes > PVRTC_CACHE_MAX_BYTES
+            {
+                let Some(evicted) = cache.pop() else { break };
+                total_bytes -= evicted.pixels.len() * std::mem::size_of::<u32>();
+            }
+            cache.insert(0, PvrtcCacheEntry {
+                key,
+                is_2bit,
+                is_opaque,
+                width: width_u,
+                height: height_u,
+                pixels: decoded.clone(),
+            });
+        });
+        decoded
+    });
+
     unsafe {
         gles.TexImage2D(
             target,


### PR DESCRIPTION
Performance fixes for Unity-based iOS games such as Blades of Brim:

- Replaces the GLES2 presentation CPU readback path with a GPU copy.
- Reuses the presentation FBO and texture storage, using glCopyTexSubImage2D instead of reallocating with glCopyTexImage2D every frame.
- Uploads the static presentation quad once instead of calling BufferData every frame.
- Saves/restores only the two vertex attributes owned by the presenter instead of querying all 16.
- Keeps a deeper OpenAL queue to reduce underruns.
- Removes the hard-coded 16 ms delay from SCNetworkReachability scheduling.
- Keeps the PVRTC decode cache and malformed-input guards.

Validation:
- cargo check --release: passed.
- cargo build --release: passed.
- Blades of Brim reached the first frame and frame 300 without runtime errors.
- The GPU path reports cached FBO + glCopyTexSubImage2D.
- The test environment reports about 30 FPS even with --fps-limit=off, so that remaining 30 FPS is the game/runtime target or software-renderer limit, not HyperHLE's limiter.

Tested on the HyperHLE/Lol fork branch perf/gles-present-pvrtc-cache.